### PR TITLE
Custom clonotype definition

### DIFF
--- a/.changeset/thin-lands-battle.md
+++ b/.changeset/thin-lands-battle.md
@@ -1,0 +1,8 @@
+---
+'@platforma-open/milaboratories.clonotype-enrichment.software': minor
+'@platforma-open/milaboratories.clonotype-enrichment.workflow': minor
+'@platforma-open/milaboratories.clonotype-enrichment.model': minor
+'@platforma-open/milaboratories.clonotype-enrichment.ui': minor
+---
+
+Custom clonotype definition for enrichment analysis

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -36,6 +36,7 @@ export type BlockArgs = {
   conditionOrder: string[];
   downsampling: DownsamplingParameters;
   filteringMode: 'none' | 'single-sample';
+  clonotypeDefinition: SUniversalPColumnId[];
 };
 
 export const model = BlockModel.create()
@@ -46,6 +47,7 @@ export const model = BlockModel.create()
       type: 'hypergeometric',
       valueChooser: 'auto',
     },
+    clonotypeDefinition: [],
     filteringMode: 'none',
   })
 
@@ -92,6 +94,19 @@ export const model = BlockModel.create()
     },
     ], { includeNativeLabel: true }),
   )
+
+  .output('sequenceColumnOptions', (ctx) => {
+    const anchor = ctx.args.abundanceRef;
+    if (anchor === undefined) return undefined;
+    return ctx.resultPool.getCanonicalOptions({ main: anchor },
+      [{
+        axes: [
+          { anchor: 'main', idx: 1 },
+        ],
+        name: 'pl7.app/vdj/sequence',
+      }],
+    );
+  })
 
   .output('metadataOptions', (ctx) => {
     const anchor = ctx.args.abundanceRef;

--- a/software/src/enrichment.py
+++ b/software/src/enrichment.py
@@ -3,6 +3,7 @@ import numpy as np
 import json
 from typing import List, Dict, Optional, Tuple
 
+
 def filter_clonotypes_by_criteria(
     aggregated_df: pl.DataFrame,
     condition_order: List[str],
@@ -11,69 +12,80 @@ def filter_clonotypes_by_criteria(
 ) -> pl.DataFrame:
     """
     Filter clonotypes based on specified criteria.
-    
+
     Args:
         aggregated_df: DataFrame with columns [elementId, condition, abundance]
         condition_order: List of conditions in order
         filter_single_sample: If True, remove clonotypes present in only one sample
         filter_any_zero: If True, remove clonotypes with zero abundance in any sample
-    
+
     Returns:
         Filtered DataFrame with same structure as input
     """
     if not (filter_single_sample or filter_any_zero):
         return aggregated_df
-    
+
     # Create pivot table to analyze abundance patterns
     pivot_for_filtering = (
         aggregated_df
         .pivot(values='abundance', index='elementId', on='condition', aggregate_function='sum')
         .fill_null(0)
     )
-    
+
     # Ensure all conditions are present
     for condition in condition_order:
         if condition not in pivot_for_filtering.columns:
-            pivot_for_filtering = pivot_for_filtering.with_columns(pl.lit(0).alias(condition))
-    
+            pivot_for_filtering = pivot_for_filtering.with_columns(
+                pl.lit(0).alias(condition))
+
     # Select condition columns in the specified order
-    condition_cols = [col for col in condition_order if col in pivot_for_filtering.columns]
-    pivot_for_filtering = pivot_for_filtering.select(['elementId'] + condition_cols)
-    
+    condition_cols = [
+        col for col in condition_order if col in pivot_for_filtering.columns]
+    pivot_for_filtering = pivot_for_filtering.select(
+        ['elementId'] + condition_cols)
+
     elements_to_keep = None
-    
+
     if filter_single_sample:
         # Filter out clonotypes present in only one sample (zero abundance in all but one)
         # Count non-zero abundances per clonotype
         non_zero_counts = pivot_for_filtering.with_columns(
-            pl.concat_list([pl.when(pl.col(col) > 0).then(1).otherwise(0) for col in condition_cols])
+            pl.concat_list([pl.when(pl.col(col) > 0).then(
+                1).otherwise(0) for col in condition_cols])
             .list.sum()
             .alias('non_zero_count')
         )
-        
+
         # Keep clonotypes present in more than one sample
-        single_sample_filter = non_zero_counts.filter(pl.col('non_zero_count') > 1).select('elementId')
-        elements_to_keep = single_sample_filter if elements_to_keep is None else elements_to_keep.join(single_sample_filter, on='elementId', how='inner')
-    
+        single_sample_filter = non_zero_counts.filter(
+            pl.col('non_zero_count') > 1).select('elementId')
+        elements_to_keep = single_sample_filter if elements_to_keep is None else elements_to_keep.join(
+            single_sample_filter, on='elementId', how='inner')
+
     if filter_any_zero:
         # Filter out clonotypes with zero abundance in any sample
         # Keep only clonotypes with non-zero abundance in ALL samples
         all_non_zero = pivot_for_filtering.with_columns(
-            pl.concat_list([pl.when(pl.col(col) > 0).then(1).otherwise(0) for col in condition_cols])
+            pl.concat_list([pl.when(pl.col(col) > 0).then(
+                1).otherwise(0) for col in condition_cols])
             .list.sum()
             .alias('non_zero_count')
         )
-        
+
         # Keep clonotypes present in ALL samples
-        any_zero_filter = all_non_zero.filter(pl.col('non_zero_count') == len(condition_cols)).select('elementId')
-        elements_to_keep = any_zero_filter if elements_to_keep is None else elements_to_keep.join(any_zero_filter, on='elementId', how='inner')
-    
+        any_zero_filter = all_non_zero.filter(
+            pl.col('non_zero_count') == len(condition_cols)).select('elementId')
+        elements_to_keep = any_zero_filter if elements_to_keep is None else elements_to_keep.join(
+            any_zero_filter, on='elementId', how='inner')
+
     if elements_to_keep is not None:
         # Filter the original aggregated data
-        filtered_df = aggregated_df.join(elements_to_keep, on='elementId', how='inner')
+        filtered_df = aggregated_df.join(
+            elements_to_keep, on='elementId', how='inner')
         return filtered_df
     else:
         return aggregated_df
+
 
 def hybrid_enrichment_analysis(
     input_data_csv: str,
@@ -91,11 +103,12 @@ def hybrid_enrichment_analysis(
     min_enrichment: float = 3,
     filter_clonotypes: bool = False,
     filter_single_sample: bool = False,
-    filter_any_zero: bool = False
+    filter_any_zero: bool = False,
+    clonotype_definition_csv: Optional[str] = None
 ) -> None:
     """
     Optimized hybrid enrichment analysis using polars for better performance and memory efficiency.
-    
+
     New filtering options:
     - filter_clonotypes: Enable clonotype filtering before enrichment calculation
     - filter_single_sample: Remove clonotypes present in only one sample (zero abundance in all but one)
@@ -104,22 +117,55 @@ def hybrid_enrichment_analysis(
     # Read data with polars lazy evaluation
     input_df = pl.scan_csv(input_data_csv)
 
+    if clonotype_definition_csv:
+        clonotype_def_df = pl.scan_csv(clonotype_definition_csv)
+
+        # Eagerly collect to perform join
+        input_df = input_df.collect()
+        clonotype_def_df = clonotype_def_df.collect()
+
+        # Join with main data
+        input_df = input_df.join(clonotype_def_df, on='elementId', how='left')
+
+        clonotype_def_cols = [
+            col for col in input_df.columns if col.startswith('clonotypeDefinition_')]
+
+        if clonotype_def_cols:
+            # Calculate new abundance
+            grouped_abundance = input_df.group_by(clonotype_def_cols + ['condition']).agg(
+                pl.col('downsampledAbundance').sum().alias('new_abundance')
+            )
+
+            # Join back to get the new abundance for each row
+            input_df = input_df.join(
+                grouped_abundance, on=clonotype_def_cols + ['condition'], how='left')
+
+            # Replace original abundance
+            input_df = input_df.with_columns(
+                pl.col('new_abundance').alias('downsampledAbundance')
+            ).drop('new_abundance')
+
+        # Continue with lazy evaluation
+        input_df = input_df.lazy()
+
     # Make sure condition_order is a list of strings
     condition_order = [str(cond) for cond in condition_order]
-    
+
     # Rename and validate columns
     input_df = input_df.rename({"downsampledAbundance": "abundance"})
-    
+
     # Validate expected columns - collect only schema to avoid loading full data
     schema = input_df.collect_schema()
     expected_cols = {'sampleId', 'elementId', 'abundance', 'condition'}
     missing_cols = expected_cols - set(schema.names())
     if missing_cols:
-        raise ValueError(f"Missing expected columns: {', '.join(missing_cols)}")
-    
+        raise ValueError(
+            f"Missing expected columns: {', '.join(missing_cols)}")
+
     # Select only needed columns to reduce memory and ensure condition is string type
-    input_df = input_df.select(['elementId', 'abundance', 'condition']).with_columns(pl.col('condition').cast(pl.Utf8))
-    
+    input_df = input_df.select(['elementId', 'abundance', 'condition']).with_columns(
+        pl.col('condition').cast(pl.Utf8))
+
     # Calculate total reads per condition efficiently
     total_reads = (
         input_df
@@ -128,8 +174,9 @@ def hybrid_enrichment_analysis(
         .collect()
         .to_dict(as_series=False)
     )
-    total_reads_dict = dict(zip(total_reads['condition'], total_reads['total_reads']))
-    
+    total_reads_dict = dict(
+        zip(total_reads['condition'], total_reads['total_reads']))
+
     # Create aggregated data first, then pivot (pivot requires DataFrame, not LazyFrame)
     aggregated_df = (
         input_df
@@ -137,41 +184,44 @@ def hybrid_enrichment_analysis(
         .agg(pl.col('abundance').sum().alias('abundance'))
         .collect()
     )
-    
+
     # Generate consistent labels BEFORE filtering based on alphabetical elementId order
     # This ensures each clonotype gets the same label regardless of filtering
-    all_element_ids = aggregated_df.select('elementId').unique().sort('elementId')
+    all_element_ids = aggregated_df.select(
+        'elementId').unique().sort('elementId')
     label_mapping = all_element_ids.with_row_index("_row_index").with_columns(
-        (pl.col('_row_index') + 1).map_elements(lambda x: f"C{int(x)}", return_dtype=pl.Utf8).alias('Label')
+        (pl.col('_row_index') +
+         1).map_elements(lambda x: f"C{int(x)}", return_dtype=pl.Utf8).alias('Label')
     ).select(['elementId', 'Label'])
-    
+
     # Apply clonotype filtering if requested
     if filter_clonotypes:
         aggregated_df = filter_clonotypes_by_criteria(
             aggregated_df, condition_order, filter_single_sample, filter_any_zero
         )
-    
+
     # Create pivot table to match pandas behavior exactly (elementId as index)
     pivot_df = (
         aggregated_df
         .pivot(values='abundance', index='elementId', on='condition', aggregate_function='sum')
         .fill_null(0)
     )
-    
+
     # Ensure all conditions are present in pivot
     for condition in condition_order:
         if condition not in pivot_df.columns:
             pivot_df = pivot_df.with_columns(pl.lit(0).alias(condition))
-    
+
     # Convert elementId to index by setting it aside (to match pandas index behavior)
     pivot_df = pivot_df.sort('elementId')  # Ensure consistent ordering
     element_ids = pivot_df.select('elementId').to_series()
-    
+
     # CRITICAL: Ensure column order matches pandas exactly (pandas unstack creates alphabetical order)
     condition_cols = [col for col in pivot_df.columns if col != 'elementId']
-    condition_cols_sorted = sorted(condition_cols)  # pandas unstack creates alphabetical order
+    # pandas unstack creates alphabetical order
+    condition_cols_sorted = sorted(condition_cols)
     pivot_df = pivot_df.select(condition_cols_sorted)
-    
+
     # Pre-calculate frequencies for all conditions efficiently
     freq_expressions = []
     for condition in condition_order:
@@ -181,35 +231,39 @@ def hybrid_enrichment_analysis(
         freq_expressions.append(
             (pl.col(condition) / total).alias(f'freq_{condition}')
         )
-    
+
     # Add frequency columns
     pivot_df = pivot_df.with_columns(freq_expressions)
-    
+
     # Calculate enrichments efficiently using vectorized operations
     enrichment_results = _calculate_enrichments_vectorized(
         pivot_df, condition_order, total_reads_dict, use_penalty, penalty_enrich, penalty_deplete
     )
-    
+
     # Add elementId back as the first column (matching pandas index->column conversion)
     enrichment_results = enrichment_results.with_columns(
         pl.Series('elementId', element_ids)
     )
-    
+
     # Apply label mapping to the enriched results
-    enrichment_results = enrichment_results.join(label_mapping, on='elementId', how='left')
-    
+    enrichment_results = enrichment_results.join(
+        label_mapping, on='elementId', how='left')
+
     # Reorder columns to match original pandas implementation: elementId, Label, then other columns
-    other_cols = [col for col in enrichment_results.columns if col not in ['elementId', 'Label']]
-    enrichment_results = enrichment_results.select(['elementId', 'Label'] + other_cols)
-    
+    other_cols = [col for col in enrichment_results.columns if col not in [
+        'elementId', 'Label']]
+    enrichment_results = enrichment_results.select(
+        ['elementId', 'Label'] + other_cols)
+
     # Save main enrichment results
     enrichment_results.write_csv(enrichment_csv)
-    
+
     # Process outputs efficiently
     _process_outputs(
         enrichment_results, condition_order, bubble_csv, top_enriched_csv,
         top_20_csv, highest_enrichment_csv, top_n_bubble, top_n_enriched, min_enrichment
     )
+
 
 def _calculate_enrichments_vectorized(
     pivot_df: pl.DataFrame,
@@ -223,32 +277,34 @@ def _calculate_enrichments_vectorized(
     Calculate enrichments using vectorized operations for better performance.
     """
     # Calculate min non-zero abundance for penalty calculations
-    abundance_cols = [col for col in pivot_df.columns if col in condition_order]
-    
+    abundance_cols = [
+        col for col in pivot_df.columns if col in condition_order]
+
     if use_penalty:
         # Calculate min non-zero abundance per row efficiently
         min_nonzero_expr = pl.concat_list([
-            pl.when(pl.col(col) > 0).then(pl.col(col)).otherwise(None) 
+            pl.when(pl.col(col) > 0).then(pl.col(col)).otherwise(None)
             for col in abundance_cols
         ]).list.min().fill_null(1).alias('min_nonzero_abundance')
-        
+
         pivot_df = pivot_df.with_columns(min_nonzero_expr)
-    
+
     # Calculate all pairwise enrichments efficiently
     enrichment_exprs = []
     freq_exprs = []
     enrichment_col_names = []  # Track enrichment column names explicitly
-    
+
     for i, condition in enumerate(condition_order):
-        freq_exprs.append(pl.col(f'freq_{condition}').alias(f'Frequency {condition}'))
-    
+        freq_exprs.append(pl.col(f'freq_{condition}').alias(
+            f'Frequency {condition}'))
+
     for num_i in range(1, len(condition_order)):
         for den_j in range(num_i):
             numerator = condition_order[num_i]
             denominator = condition_order[den_j]
             enrichment_col_name = f'Enrichment {numerator} vs {denominator}'
             enrichment_col_names.append(enrichment_col_name)
-            
+
             if use_penalty:
                 # This logic has been rewritten to EXACTLY match the original pandas implementation.
                 # The original code creates two separate frequency dictionaries (num_freqs, den_freqs)
@@ -261,18 +317,22 @@ def _calculate_enrichments_vectorized(
                     pl.col(f'freq_{numerator}')
                 ).otherwise(
                     pl.when(numerator != condition_order[0]).then(
-                        pl.col('min_nonzero_abundance').cast(pl.Float64) / (penalty_deplete * total_reads_dict.get(numerator, 1))
-                    ).otherwise(0.0)  # Use 0.0 if it's the first condition with 0 abundance
+                        pl.col('min_nonzero_abundance').cast(pl.Float64) /
+                        (penalty_deplete * total_reads_dict.get(numerator, 1))
+                        # Use 0.0 if it's the first condition with 0 abundance
+                    ).otherwise(0.0)
                 )
-                
+
                 # Denominator frequency expression:
                 # A penalty is applied only if the clonotype abundance is 0 AND it's not the LAST condition.
                 den_freq_expr = pl.when(pl.col(denominator) > 0).then(
                     pl.col(f'freq_{denominator}')
                 ).otherwise(
                     pl.when(denominator != condition_order[-1]).then(
-                        pl.col('min_nonzero_abundance').cast(pl.Float64) / (penalty_enrich * total_reads_dict.get(denominator, 1))
-                    ).otherwise(0.0)  # Use 0.0 if it's the last condition with 0 abundance
+                        pl.col('min_nonzero_abundance').cast(
+                            pl.Float64) / (penalty_enrich * total_reads_dict.get(denominator, 1))
+                        # Use 0.0 if it's the last condition with 0 abundance
+                    ).otherwise(0.0)
                 )
             else:
                 # Fixed bug for no_penalty case: add pseudocount for 0 abundance
@@ -285,7 +345,7 @@ def _calculate_enrichments_vectorized(
                 den_freq_expr = pl.when(pl.col(denominator) > 0).then(
                     pl.col(f'freq_{denominator}')
                 ).otherwise(1.0 / den_total)
-            
+
             # Calculate enrichment with proper handling of edge cases
             enrichment_expr = (
                 pl.when(den_freq_expr > 0)
@@ -293,28 +353,31 @@ def _calculate_enrichments_vectorized(
                 .otherwise(None)
                 .alias(enrichment_col_name)
             )
-            
+
             enrichment_exprs.append(enrichment_expr)
-    
+
     # Add frequency and enrichment columns first
     result_df = pivot_df.with_columns(freq_exprs + enrichment_exprs)
-    
+
     # Now calculate max positive enrichment to match original pandas behavior
     if enrichment_col_names:
         # Match original pandas behavior: clip negative values to 0, then find max
         max_pos_enrich_expr = pl.concat_list([
-            pl.when(pl.col(col).is_null()).then(0).otherwise(pl.col(col).clip(lower_bound=0))
+            pl.when(pl.col(col).is_null()).then(
+                0).otherwise(pl.col(col).clip(lower_bound=0))
             for col in enrichment_col_names
         ]).list.max().alias('MaxPositiveEnrichment')
-        
+
         result_df = result_df.with_columns(max_pos_enrich_expr)
-    
+
     # Select only needed columns (elementId will be added back in main function)
-    freq_col_names = [f'Frequency {condition}' for condition in condition_order]
+    freq_col_names = [
+        f'Frequency {condition}' for condition in condition_order]
     result_cols = freq_col_names + enrichment_col_names
     if enrichment_col_names:  # Only add MaxPositiveEnrichment if we have enrichment columns
         result_cols.append('MaxPositiveEnrichment')
     return result_df.select(result_cols)
+
 
 def _process_outputs(
     enrichment_results: pl.DataFrame,
@@ -331,14 +394,15 @@ def _process_outputs(
     Process and save output files efficiently.
     """
     # Process enrichment data for detailed output
-    enrichment_cols = [col for col in enrichment_results.columns if col.startswith('Enrichment ')]
-    
+    enrichment_cols = [
+        col for col in enrichment_results.columns if col.startswith('Enrichment ')]
+
     if enrichment_cols:
         # Create detailed enrichment table efficiently
         enrichment_detailed = _create_detailed_enrichment_table(
             enrichment_results, enrichment_cols, condition_order
         )
-        
+
         # Save highest enrichment if requested
         if highest_enrichment_csv:
             highest_enrichment = (
@@ -349,19 +413,19 @@ def _process_outputs(
                 .sort(['Enrichment', 'elementId'], descending=[True, False])
             )
             highest_enrichment.write_csv(highest_enrichment_csv)
-        
+
         # Process bubble data
         bubble_data = _create_bubble_data(
             enrichment_results, condition_order, top_n_bubble, min_enrichment
         )
         bubble_data.write_csv(bubble_csv)
-        
+
         # Process top enriched data
         top_enriched_data = _create_top_enriched_data(
             enrichment_results, condition_order, bubble_data, top_n_enriched
         )
         top_enriched_data.write_csv(top_enriched_csv)
-        
+
         # Process top 20 data if requested
         if top_20_csv:
             top_20_data = _create_top_enriched_data(
@@ -370,15 +434,18 @@ def _process_outputs(
             top_20_data.write_csv(top_20_csv)
     else:
         # Create empty outputs if no enrichment columns
-        empty_cols = ['elementId', 'Label', 'Comparison', 'Numerator', 'Denominator', 'Enrichment', 'Frequency_Numerator']
-        empty_df = pl.DataFrame(schema={col: pl.Utf8 if col in ['elementId', 'Label', 'Comparison', 'Numerator', 'Denominator'] else pl.Float64 for col in empty_cols})
-        
+        empty_cols = ['elementId', 'Label', 'Comparison', 'Numerator',
+                      'Denominator', 'Enrichment', 'Frequency_Numerator']
+        empty_df = pl.DataFrame(schema={col: pl.Utf8 if col in [
+                                'elementId', 'Label', 'Comparison', 'Numerator', 'Denominator'] else pl.Float64 for col in empty_cols})
+
         empty_df.write_csv(bubble_csv)
         empty_df.write_csv(top_enriched_csv)
         if top_20_csv:
             empty_df.write_csv(top_20_csv)
         if highest_enrichment_csv:
             empty_df.write_csv(highest_enrichment_csv)
+
 
 def _create_detailed_enrichment_table(
     enrichment_results: pl.DataFrame,
@@ -400,14 +467,17 @@ def _create_detailed_enrichment_table(
         )
         .filter(pl.col('Enrichment').is_not_null())
     )
-    
+
     # Extract numerator and denominator
     enrichment_melted = enrichment_melted.with_columns([
-        pl.col('Comparison').str.replace('Enrichment ', '').alias('comparison_clean'),
-        pl.col('Comparison').str.replace('Enrichment ', '').str.split(' vs ').list.get(0).alias('Numerator'),
-        pl.col('Comparison').str.replace('Enrichment ', '').str.split(' vs ').list.get(1).alias('Denominator')
+        pl.col('Comparison').str.replace(
+            'Enrichment ', '').alias('comparison_clean'),
+        pl.col('Comparison').str.replace('Enrichment ', '').str.split(
+            ' vs ').list.get(0).alias('Numerator'),
+        pl.col('Comparison').str.replace('Enrichment ', '').str.split(
+            ' vs ').list.get(1).alias('Denominator')
     ])
-    
+
     # Add frequency data
     freq_cols = [f'Frequency {cond}' for cond in condition_order]
     freq_melted = (
@@ -420,11 +490,12 @@ def _create_detailed_enrichment_table(
             value_name='Frequency_Numerator'
         )
         .with_columns(
-            pl.col('ConditionFull').str.replace('Frequency ', '').alias('Numerator')
+            pl.col('ConditionFull').str.replace(
+                'Frequency ', '').alias('Numerator')
         )
         .select(['elementId', 'Label', 'Numerator', 'Frequency_Numerator'])
     )
-    
+
     # Join enrichment with frequency data
     result = enrichment_melted.join(
         freq_melted,
@@ -433,8 +504,9 @@ def _create_detailed_enrichment_table(
     ).select([
         'elementId', 'Label', 'comparison_clean', 'Numerator', 'Denominator', 'Enrichment', 'Frequency_Numerator'
     ]).rename({'comparison_clean': 'Comparison'})
-    
+
     return result
+
 
 def _create_bubble_data(
     enrichment_results: pl.DataFrame,
@@ -449,14 +521,14 @@ def _create_bubble_data(
     filtered_data = enrichment_results.filter(
         pl.col('MaxPositiveEnrichment') >= min_enrichment
     )
-    
+
     if filtered_data.height == 0:
         return pl.DataFrame(schema={
             'elementId': pl.Utf8, 'Label': pl.Utf8, 'Numerator': pl.Utf8,
             'Denominator': pl.Utf8, 'Enrichment': pl.Float64,
             'Frequency_Numerator': pl.Float64, 'MaxPositiveEnrichment': pl.Float64
         })
-    
+
     # Get top clonotypes
     top_clonotypes = (
         filtered_data
@@ -466,19 +538,21 @@ def _create_bubble_data(
         .head(top_n_bubble)
         .select('elementId')
     )
-    
+
     # Filter data for top clonotypes
-    bubble_data = filtered_data.join(top_clonotypes, on='elementId', how='inner')
-    
+    bubble_data = filtered_data.join(
+        top_clonotypes, on='elementId', how='inner')
+
     # Create bubble data efficiently
-    enrichment_cols = [col for col in bubble_data.columns if col.startswith('Enrichment ')]
+    enrichment_cols = [
+        col for col in bubble_data.columns if col.startswith('Enrichment ')]
     bubble_rows = []
-    
+
     for row in bubble_data.iter_rows(named=True):
         element_id = row['elementId']
         label = row['Label']
         max_pos_enrich = row['MaxPositiveEnrichment']
-        
+
         for col in enrichment_cols:
             enrich_val = row[col]
             if enrich_val is not None and enrich_val > 0:
@@ -486,7 +560,7 @@ def _create_bubble_data(
                 comparison = col.replace('Enrichment ', '')
                 numerator, denominator = comparison.split(' vs ')
                 freq_val = row.get(f'Frequency {numerator}', None)
-                
+
                 bubble_rows.append({
                     'elementId': element_id,
                     'Label': label,
@@ -496,7 +570,7 @@ def _create_bubble_data(
                     'Frequency_Numerator': freq_val,
                     'MaxPositiveEnrichment': max_pos_enrich
                 })
-    
+
     if bubble_rows:
         return pl.DataFrame(bubble_rows)
     else:
@@ -505,6 +579,7 @@ def _create_bubble_data(
             'Denominator': pl.Utf8, 'Enrichment': pl.Float64,
             'Frequency_Numerator': pl.Float64, 'MaxPositiveEnrichment': pl.Float64
         })
+
 
 def _create_top_enriched_data(
     enrichment_results: pl.DataFrame,
@@ -519,7 +594,7 @@ def _create_top_enriched_data(
         return pl.DataFrame(schema={
             'elementId': pl.Utf8, 'Label': pl.Utf8, 'Condition': pl.Utf8, 'Frequency': pl.Float64
         })
-    
+
     # Get top element IDs
     top_ids = (
         bubble_data
@@ -529,7 +604,7 @@ def _create_top_enriched_data(
         .head(top_n)
         .select('elementId')
     )
-    
+
     # Create frequency data
     freq_cols = [f'Frequency {cond}' for cond in condition_order]
     freq_data = (
@@ -543,33 +618,44 @@ def _create_top_enriched_data(
             value_name='Frequency'
         )
         .with_columns(
-            pl.col('ConditionFull').str.replace('Frequency ', '').alias('Condition')
+            pl.col('ConditionFull').str.replace(
+                'Frequency ', '').alias('Condition')
         )
         .select(['elementId', 'Label', 'Condition', 'Frequency'])
     )
-    
+
     return freq_data
+
 
 if __name__ == "__main__":
     import argparse
 
-    parser = argparse.ArgumentParser(description="Optimized Hybrid Enrichment Analysis")
-    parser.add_argument("--input_data", required=True, help="Path to the combined input CSV file. Expected columns: sampleId, elementId, abundance, downsampledAbundance, and condition.")
+    parser = argparse.ArgumentParser(
+        description="Optimized Hybrid Enrichment Analysis")
+    parser.add_argument("--input_data", required=True,
+                        help="Path to the combined input CSV file. Expected columns: sampleId, elementId, abundance, downsampledAbundance, and condition.")
     parser.add_argument("--conditions", type=str, required=True)
     parser.add_argument("--enrichment", required=True)
     parser.add_argument("--bubble", required=True)
     parser.add_argument("--top_enriched", required=True)
     parser.add_argument("--top_20", required=False)
-    parser.add_argument("--highest_enrichment_clonotype", required=False, help="Optional CSV output for rows with the highest enrichment per elementId-Label combination.")
+    parser.add_argument("--highest_enrichment_clonotype", required=False,
+                        help="Optional CSV output for rows with the highest enrichment per elementId-Label combination.")
     parser.add_argument("--use_penalty", action="store_true")
     parser.add_argument("--penalty_enrich", type=int, default=2)
     parser.add_argument("--penalty_deplete", type=int, default=10)
     parser.add_argument("--top_n_bubble", type=int, default=20)
     parser.add_argument("--top_n_enriched", type=int, default=5)
-    parser.add_argument("--min_enrichment", required=False, type=float, default=0)
-    parser.add_argument("--filter_clonotypes", action="store_true", help="Enable clonotype filtering before enrichment calculation")
-    parser.add_argument("--filter_single_sample", action="store_true", help="Remove clonotypes present in only one sample (zero abundance in all but one)")
-    parser.add_argument("--filter_any_zero", action="store_true", help="Remove clonotypes absent in any sample (zero abundance in any sample)")
+    parser.add_argument("--min_enrichment", required=False,
+                        type=float, default=0)
+    parser.add_argument("--filter_clonotypes", action="store_true",
+                        help="Enable clonotype filtering before enrichment calculation")
+    parser.add_argument("--filter_single_sample", action="store_true",
+                        help="Remove clonotypes present in only one sample (zero abundance in all but one)")
+    parser.add_argument("--filter_any_zero", action="store_true",
+                        help="Remove clonotypes absent in any sample (zero abundance in any sample)")
+    parser.add_argument("--clonotype-definition", required=False,
+                        help="Path to clonotype definition CSV file.")
 
     args = parser.parse_args()
 
@@ -589,5 +675,6 @@ if __name__ == "__main__":
         min_enrichment=args.min_enrichment,
         filter_clonotypes=args.filter_clonotypes,
         filter_single_sample=args.filter_single_sample,
-        filter_any_zero=args.filter_any_zero
+        filter_any_zero=args.filter_any_zero,
+        clonotype_definition_csv=args.clonotype_definition
     )

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -5,6 +5,7 @@ import type {
   ListOption,
 } from '@platforma-sdk/ui-vue';
 import {
+  PlAccordionSection,
   PlAgDataTableV2,
   PlBlockPage,
   PlBtnGhost,
@@ -184,6 +185,19 @@ const createStatsTable = () => {
         </div>
       </template>
     </PlBtnGroup>
+
+    <PlAccordionSection label="Advanced Settings">
+      <PlDropdownMulti
+        v-model="app.model.args.clonotypeDefinition"
+        :options="app.model.outputs.sequenceColumnOptions"
+        label="Clonotype definition"
+      >
+        <template #tooltip>
+          Select columns that define a clonotype. By default, it's a nucletotide sequence of the clonotype.
+          Here you can override this behavior and calculate enrichment score based on e.g. amino acid sequence of CDR3.
+        </template>
+      </PlDropdownMulti>
+    </PlAccordionSection>
   </PlSlideModal>
   <!-- Slide window with computed variables -->
   <PlDialogModal

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -24,6 +24,12 @@ wf.prepare(func(args){
 	bundleBuilder.addAnchor("main", args.abundanceRef) 
 	bundleBuilder.addSingle(args.conditionColumnRef)
 
+	if args.clonotypeDefinition != undefined {
+        for columnRef in args.clonotypeDefinition {
+            bundleBuilder.addSingle(columnRef)
+        }
+    }
+
 	return {
 		columns: bundleBuilder.build()
 	}
@@ -73,6 +79,18 @@ wf.body(func(args) {
 	cloneTable.cpu(1)
 	cloneTable = cloneTable.build()
 
+	clonotypeDefinitionFile := undefined
+    if args.clonotypeDefinition != undefined && len(args.clonotypeDefinition) > 0 {
+        clonotypeDefinitionTable := pframes.csvFileBuilder()
+        for i, columnRef in args.clonotypeDefinition {
+            clonotypeDefinitionTable.add(columns.getColumn(columnRef), {header: "clonotypeDefinition_" + i})
+        }
+        clonotypeDefinitionTable.setAxisHeader(abundanceSpec.axesSpec[1].name, "elementId")
+        clonotypeDefinitionTable.mem("16GiB")
+        clonotypeDefinitionTable.cpu(1)
+        clonotypeDefinitionFile = clonotypeDefinitionTable.build()
+    }
+
 	runDownsampling := exec.builder().
 		software(downsamplingSw).
 		mem("32GiB").
@@ -107,6 +125,11 @@ wf.body(func(args) {
 		arg("--top_20").arg("top_20.csv").
 		// arg("--min_enrichment").arg(string(enrichmentThreshold)).
 		arg("--highest_enrichment_clonotype").arg("highest_enrichment_clonotype.csv")
+
+	if clonotypeDefinitionFile != undefined {
+        calculateEnrichment = calculateEnrichment.addFile("clonotypeDefinition.csv", clonotypeDefinitionFile).
+		    arg("--clonotype-definition").arg("clonotypeDefinition.csv")
+    }
 
 	// Add filtering flags based on user selection
 	if filteringMode != "none" {


### PR DESCRIPTION
Previously, the enrichment analysis was tied to the default clonotype definition from the input data (e.g., the full nucleotide sequence from MiXCR). This update adds an advanced setting that allows users to define what constitutes a clonotype for the purpose of the analysis.

- Flexible Clonotype Definition: A new optional "Clonotype definition" setting has been added to the block's advanced settings. Users can now select one or more sequence columns (e.g., Amino Acid sequence of CDR(s) etc.) to define a clonotype.

- Dynamic Abundance Recalculation: If a custom clonotype definition is provided, the software dynamically recalculates clone abundances. It groups all records that share the same sequences/genes in the user-selected columns and sums their abundances.

- Targeted Analysis: This change enables users to perform more targeted enrichment analysis. For instance, it can identify clonotypes that are enriched based on their amino acid sequence, ignoring underlying nucleotide differences, which is crucial for antibody and TCR discovery workflows.

- Implementation: The changes span the block's model, UI, workflow, and software to support this new functionality, from user input to the final calculation.