### PR TITLE
fix: prevent run button flicker when upstream blocks recalculate

### DIFF
--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -53,6 +53,13 @@ watchEffect(() => {
   const sequenceColumnOptions = app.model.outputs.sequenceColumnOptions;
   const baseFilter = app.model.args.FilteringConfig.baseFilter;
 
+  // Skip label update when sequenceColumnOptions is transiently unavailable but clonotype
+  // definitions are selected — avoids arg churn that marks the block stale and flickers the
+  // run button while upstream blocks are recalculating.
+  if (clonotypeDefinition && clonotypeDefinition.length > 0 && !sequenceColumnOptions) {
+    return;
+  }
+
   let label = '';
 
   // Add clonotype definition prefix if selected
@@ -581,9 +588,10 @@ watch(() => app.model.args.antigenControlConfig.controlEnabled, (enabled) => {
   }
 });
 
-// Sync control flags to model
+// Sync control flags to model — only when metadata is loaded to avoid transient arg changes
+// that mark the block stale and flicker the run button while upstream blocks recalculate.
 watchEffect(() => {
-  if (app.model.args.antigenControlConfig) {
+  if (app.model.args.antigenControlConfig && antigenConditionsMap.value) {
     app.model.args.antigenControlConfig.hasSingleConditionNegativeControl = hasSingleSampleNegativeControl.value;
     app.model.args.antigenControlConfig.hasMultiConditionNegativeControl = hasMultiSampleNegativeControl.value;
   }


### PR DESCRIPTION
## Issue Raised
https://platforma-bio.slack.com/archives/C0AMSHEPSSK/p1775212285578989

## Summary

The run button on the clonotype enrichment block flickers on and off while upstream blocks are recalculating. This happens because two `watchEffect`s write to block args based on result-pool-derived data that becomes transiently unavailable during upstream execution.

## Root cause

Platforma marks a block stale — and shows the run button — whenever current args differ from the args used in the last production run (`!argsEquals(currentArgs, prodArgs)`). Two UI `watchEffect`s modify args in response to model outputs that depend on the result pool:

1. **`defaultBlockLabel`** — Built from `sequenceColumnOptions` (a result pool query). When upstream blocks run, `sequenceColumnOptions` briefly becomes `undefined`, dropping the clonotype definition prefix from the label. Args change → block goes stale → run button appears. Result pool settles → label restores → args match again → button disappears.

2. **`hasSingleConditionNegativeControl` / `hasMultiConditionNegativeControl`** — Synced from `antigenConditionsMap`, which derives from metadata fetched via the result pool. Same transient unavailability → flags flip to `false` → args change → stale → flicker.

With multiple upstream blocks finishing at different times, each triggers this cycle independently, producing repeated flicker.

## Fix

Guard both `watchEffect`s to skip arg writes when their dependent data is transiently unavailable:

- **`defaultBlockLabel`**: Early return when `clonotypeDefinition` is selected but `sequenceColumnOptions` is `undefined`
- **Control flags**: Only sync when `antigenConditionsMap` is defined

Args now hold their last valid values during result pool transitions, preventing false staleness toggles.

## Why this has no knock-on effects

Both guards only suppress writes during the narrow window when result-pool data is unavailable. In every case, the block cannot meaningfully be run during this window, and the correct values are written as soon as data restores:

- **Initial block creation**: `clonotypeDefinition` defaults to `[]`, so the label guard never triggers. Control flags default to `false`, which is correct when no metadata exists.
- **User changes dataset or column**: `sequenceColumnOptions` / `antigenConditionsMap` stay defined (via `useWatchFetch` retaining old values) until the new fetch completes, so both guards allow writes throughout the transition.
- **Permanent unavailability** (e.g., no dataset selected): `argsValid` already returns `false` (requires `abundanceRef`), so the run button is hidden regardless of flag values.

## Test plan

- [ ] Configure enrichment block with clonotype definitions and antigen control enabled
- [ ] Run multiple upstream blocks simultaneously
- [ ] Verify run button stays hidden (no flicker) while upstream blocks recalculate
- [ ] Verify run button appears correctly when args are actually changed
- [ ] Verify block runs correctly after upstream blocks finish