### PR TITLE
Add other VDJ region sequence columns to enrichment table

### DIFF
--- a/.changeset/add-region-sequence-columns.md
+++ b/.changeset/add-region-sequence-columns.md
@@ -1,0 +1,6 @@
+---
+"@platforma-open/milaboratories.clonotype-enrichment": patch
+'@platforma-open/milaboratories.clonotype-enrichment.model': patch
+---
+
+Add other VDJ region sequence columns (CDR1, CDR2, FR1, etc.) to the enrichment table as optional columns

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -371,34 +371,53 @@ export const model = BlockModel.create()
       return undefined;
     }
 
-    // Pull assembling feature sequences from result pool to show in the table
+    // Pull sequence columns from result pool to show in the table
     const anchor = ctx.args.abundanceRef;
     const enrichmentAxisName = pCols[0]?.spec.axesSpec[0]?.name;
-    const seqCols = anchor
+    const allSeqCols = anchor
       ? (ctx.resultPool.getAnchoredPColumns(
           { main: anchor },
           [{ axes: [{ anchor: 'main', idx: 1 }], name: 'pl7.app/vdj/sequence' }],
           { dontWaitAllData: true },
-        ) ?? []).filter((col) => {
-          const alphabet = col.spec.domain?.['pl7.app/alphabet'];
-          // !== false (not === true) to also match cluster centroid sequences,
-          // where clonotype-clustering deletes the isAssemblingFeature annotation
-          return (alphabet === 'aminoacid')
-            && readAnnotationJson(col.spec, Annotation.VDJ.IsAssemblingFeature) !== false
-            // Skip if axis doesn't match enrichment (e.g. stale results after switching input)
-            && col.spec.axesSpec[0]?.name === enrichmentAxisName;
-        }).map((col) => ({
-          ...col,
-          spec: {
-            ...col.spec,
-            annotations: { ...col.spec.annotations, 'pl7.app/table/visibility': 'default', 'pl7.app/table/orderPriority': '1' },
-          },
-        }))
+        ) ?? []).filter((col) =>
+          // Skip if axis doesn't match enrichment (e.g. stale results after switching input)
+          col.spec.axesSpec[0]?.name === enrichmentAxisName,
+        )
       : [];
+
+    // Assembling feature (or centroid) amino acid sequences — visible by default
+    const mainSeqCols = allSeqCols
+      .filter((col) => {
+        const alphabet = col.spec.domain?.['pl7.app/alphabet'];
+        // !== false (not === true) to also match cluster centroid sequences,
+        // where clonotype-clustering deletes the isAssemblingFeature annotation
+        return (alphabet === 'aminoacid')
+          && readAnnotationJson(col.spec, Annotation.VDJ.IsAssemblingFeature) !== false;
+      })
+      .map((col) => ({
+        ...col,
+        spec: {
+          ...col.spec,
+          annotations: { ...col.spec.annotations, 'pl7.app/table/visibility': 'default', 'pl7.app/table/orderPriority': '1' },
+        },
+      }));
+
+    // Other region sequences (CDR1, CDR2, FR1, etc.) — not shown by default, available in column picker
+    const otherRegionCols = allSeqCols
+      .filter((col) =>
+        readAnnotationJson(col.spec, Annotation.VDJ.IsAssemblingFeature) === false,
+      )
+      .map((col) => ({
+        ...col,
+        spec: {
+          ...col.spec,
+          annotations: { ...col.spec.annotations, 'pl7.app/table/visibility': 'optional' },
+        },
+      }));
 
     return createPlDataTableV2(
       ctx,
-      [...pCols, ...seqCols],
+      [...pCols, ...mainSeqCols, ...otherRegionCols],
       ctx.uiState.tableState,
       {
         // Sequence columns are non-core so they are left-joined: they won't

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11046,7 +11046,7 @@ snapshots:
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       estraverse: 5.3.0
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     transitivePeerDependencies:
       - supports-color
       - typescript


### PR DESCRIPTION
Pull non-assembling-feature sequence columns (CDR1, CDR2, FR1, FR2, etc.) from the result pool into the enrichment table as optional columns, available via the column picker but not shown by default.

### Hidden By Default
<img width="1027" height="926" alt="Screenshot 2026-04-10 at 12 35 35 PM" src="https://github.com/user-attachments/assets/ae34c637-f1a3-490f-ba6d-fe5a3710a234" />

### All Available
<img width="1641" height="902" alt="Screenshot 2026-04-10 at 12 36 40 PM" src="https://github.com/user-attachments/assets/8d5365b0-466d-4948-888d-67f5820a7263" />

