### PR TITLE
fix(MILAB-6212): disambiguate per-comparison Log2FC export domains

### DIFF
--- a/.changeset/fix-additional-enrichments-spec-collision.md
+++ b/.changeset/fix-additional-enrichments-spec-collision.md
@@ -1,0 +1,6 @@
+---
+'@platforma-open/milaboratories.clonotype-enrichment.workflow': patch
+'@platforma-open/milaboratories.clonotype-enrichment': patch
+---
+
+Fix `additionalEnrichments` per-comparison Log2FC columns colliding in the result pool. Each per-comparison column now carries `domain["pl7.app/enrichment/type"] = "comparison"` and `domain["pl7.app/enrichment/comparison"] = <X vs Y>`, mirroring the disambiguation pattern already used for the Overall Log2FC column. Per-comparison columns are now visible to downstream blocks (Clonotype Browser, Antibody Lead Selection).

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -328,7 +328,8 @@ wf.body(func(args) {
 			annotationStats := calculateAnnotationValues(enrichCsv, "Enrichment " + comparison)
 
 			specLabel := {
-				label: "Log2FC " + comparison
+				label: "Log2FC " + comparison,
+				comparison: comparison
 			}
 
 			exportColumnRender := render.create(enrichmentColumnTpl, {

--- a/workflow/src/pf-enrichment-conv-export.lib.tengo
+++ b/workflow/src/pf-enrichment-conv-export.lib.tengo
@@ -5,10 +5,15 @@ getColumns := func(abundanceSpec, inputType, min, max, cutoff, overall75Percenti
   ll.assert(len(opts) <= 1, "expected at most one options map")
 
   specLabel := "Max Log2FC"
+  comparison := undefined
 
-  // this same comparisons defines downstream which column will be used
+  // For per-comparison additional exports, opts[0].comparison disambiguates
+  // the spec domain so each emitted Log2FC column has a unique (name, domain, axes).
+  // Without it every comparison would collapse onto the Max column in the result pool.
   if len(opts) == 1 {
     specLabel = opts[0].label
+    ll.assert(opts[0].comparison != undefined, "expected opts.comparison for per-comparison enrichment export")
+    comparison = opts[0].comparison
   }
 
   // Extract control info
@@ -28,9 +33,16 @@ getColumns := func(abundanceSpec, inputType, min, max, cutoff, overall75Percenti
     }
   }
 
-  // Define columns for exports
-  maxDomain := copy(baseDomain)
-  maxDomain["pl7.app/enrichment/type"] = "max"
+  // Define columns for exports.
+  // Main path: type=max (Max Log2FC). Per-comparison path: type=comparison plus
+  // comparison=<X vs Y>, mirroring the Overall Log2FC disambiguation below.
+  enrichmentDomain := copy(baseDomain)
+  if comparison != undefined {
+    enrichmentDomain["pl7.app/enrichment/type"] = "comparison"
+    enrichmentDomain["pl7.app/enrichment/comparison"] = comparison
+  } else {
+    enrichmentDomain["pl7.app/enrichment/type"] = "max"
+  }
   columns := [{
         column: "Enrichment",
         id: "enrichment",
@@ -38,7 +50,7 @@ getColumns := func(abundanceSpec, inputType, min, max, cutoff, overall75Percenti
         spec: {
           name: "pl7.app/enrichment",
           valueType: "Double",
-          domain: maxDomain,
+          domain: enrichmentDomain,
           annotations: {
             "pl7.app/label": specLabel,
             "pl7.app/table/orderPriority": "9000",

--- a/workflow/src/pf-enrichment-conv-export.lib.tengo
+++ b/workflow/src/pf-enrichment-conv-export.lib.tengo
@@ -11,8 +11,9 @@ getColumns := func(abundanceSpec, inputType, min, max, cutoff, overall75Percenti
   // the spec domain so each emitted Log2FC column has a unique (name, domain, axes).
   // Without it every comparison would collapse onto the Max column in the result pool.
   if len(opts) == 1 {
-    specLabel = opts[0].label
+    ll.assert(opts[0].label != undefined, "expected opts.label for per-comparison enrichment export")
     ll.assert(opts[0].comparison != undefined, "expected opts.comparison for per-comparison enrichment export")
+    specLabel = opts[0].label
     comparison = opts[0].comparison
   }
 


### PR DESCRIPTION
## Summary

The `additionalEnrichments` export emitted per-comparison Log2FC columns with the *same* PColumn spec as the Max Log2FC column — `name=pl7.app/enrichment`, `domain={type:"max", ...}`, identical axes. The result pool keys columns by `(name, domain, axes)`, so every per-comparison column collapsed onto Max and downstream blocks (Lead Selection, Clonotype Browser, Antibody/TCR Leads) saw only a single enrichment score regardless of how many comparisons the user configured.

## Change

`workflow/src/pf-enrichment-conv-export.lib.tengo` now accepts a `comparison` field in its options object and branches the spec domain:

- **Main path** (no opts): `domain["pl7.app/enrichment/type"] = "max"` — unchanged.
- **Per-comparison path** (`opts.comparison` set): `domain["pl7.app/enrichment/type"] = "comparison"` plus `domain["pl7.app/enrichment/comparison"] = <X vs Y>`. Mirrors the disambiguation pattern already used for the Overall Log2FC column in `pf-enrichment-conv.lib.tengo`.

`workflow/src/main.tpl.tengo` populates `specLabel.comparison` in the additional-exports loop so the helper receives the comparison string. `enrichment-column.tpl.tengo` already forwards the full `specLabel` object — no edit needed.

An `ll.assert` rejects calls that pass a label without a comparison, so future regressions surface loudly instead of silently re-emitting duplicate Max columns.

## Verified on AlpacaTy1

Lead Selection's `filterConfig` (a direct view of the result pool) before vs after, with `additionalEnrichmentExports = ["C1 vs C0", "C2 vs C0"]`:

**Before:** 3 entries — Max Log2FC, Overall Log2FC, Enrichment Quality. The two configured comparisons silently collapsed onto Max.

**After:** 5 entries — Max Log2FC (`type:max`), Overall Log2FC (`type:overall, comparison:C2 vs C0`), Log2FC C1 vs C0 (`type:comparison, comparison:C1 vs C0`), Log2FC C2 vs C0 (`type:comparison, comparison:C2 vs C0`), Enrichment Quality. Max and Overall domains are unchanged; the two new entries appear with proper disambiguation.
