### PR TITLE
Julenmendieta/MILAB-6506_maxFreqPerClonotype

### DIFF
--- a/.changeset/max-frequency-export.md
+++ b/.changeset/max-frequency-export.md
@@ -1,0 +1,9 @@
+---
+'@platforma-open/milaboratories.clonotype-enrichment.software': minor
+'@platforma-open/milaboratories.clonotype-enrichment.workflow': minor
+'@platforma-open/milaboratories.clonotype-enrichment.model': minor
+'@platforma-open/milaboratories.clonotype-enrichment.ui': minor
+'@platforma-open/milaboratories.clonotype-enrichment': minor
+---
+
+Add per-clonotype Max Frequency export for cluster input. When the input is cluster abundance, the block identifies the upstream per-clonotype primary abundance (matched by the clonotype identity the cluster's `clusterId` axis carries) and computes each clonotype's maximum frequency across target rounds (library round and negative controls excluded), using the same downsampling and frequency definition as the cluster-level frequencies. Exported on the clonotype-key axis as a `pl7.app/maxFrequency` score for ranking in Lead Selection. No column is produced for clonotype/peptide input.

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -96,6 +96,11 @@ export type BlockData = {
   downsampling: DownsamplingParameters;
   FilteringConfig: FilteringConfig;
   clonotypeDefinition: SUniversalPColumnId[];
+  /**
+   * Cluster-mode only: PlRef of the upstream per-clonotype primary abundance the
+   * input cluster abundance was built from.
+   */
+  clonotypeAbundanceRef?: PlRef;
   additionalEnrichmentExports: string[];
   antigenControlConfig: AntigenControlConfig;
   enrichmentThreshold: number; // Default: 2.0 log2 FC
@@ -243,6 +248,7 @@ export const platforma = BlockModelV3.create(dataModel)
       downsampling: data.downsampling,
       FilteringConfig: data.FilteringConfig,
       clonotypeDefinition: data.clonotypeDefinition,
+      clonotypeAbundanceRef: data.clonotypeAbundanceRef,
       additionalEnrichmentExports: data.additionalEnrichmentExports,
       antigenControlConfig: data.antigenControlConfig,
       enrichmentThreshold: data.enrichmentThreshold,
@@ -295,6 +301,58 @@ export const platforma = BlockModelV3.create(dataModel)
   .output("datasetSpec", (ctx) => {
     if (ctx.data.abundanceRef) return ctx.resultPool.getPColumnSpecByRef(ctx.data.abundanceRef);
     else return undefined;
+  })
+
+  /**
+   * Cluster-mode only: identify the upstream per-clonotype primary abundance that
+   * the input cluster abundance was built from. Returns undefined for
+   * clonotype/peptide input or when no unique match exists.
+   */
+  .output("discoveredClonotypeAbundance", (ctx) => {
+    const anchor = ctx.data.abundanceRef;
+    if (!anchor) return undefined;
+    const anchorSpec = ctx.resultPool.getPColumnSpecByRef(anchor);
+    if (!anchorSpec) return undefined;
+
+    // Only when the input is cluster abundance (row axis = clusterId).
+    const clusterAxis = anchorSpec.axesSpec[1];
+    if (clusterAxis?.name !== "pl7.app/clusterId") return undefined;
+
+    // Clonotype identity = clusterId axis domain minus clustering-specific keys.
+    const identityKey = JSON.stringify(
+      Object.entries(clusterAxis.domain ?? {})
+        .filter(([k]) => !k.startsWith("pl7.app/clustering/"))
+        .sort(([a], [b]) => a.localeCompare(b)),
+    );
+
+    const isClonotypeAxis = (name: string) =>
+      name === "pl7.app/vdj/clonotypeKey" || name === "pl7.app/vdj/scClonotypeKey";
+
+    // Candidate primary, raw-count abundances keyed by sampleId × <row axis>.
+    const candidates = ctx.resultPool.getOptions([
+      {
+        axes: [{ name: "pl7.app/sampleId" }, {}],
+        annotations: {
+          "pl7.app/isAbundance": "true",
+          "pl7.app/abundance/isPrimary": "true",
+          "pl7.app/abundance/normalized": "false",
+        },
+      },
+    ]);
+
+    // Keep those whose row axis is a clonotype key carrying the matching identity.
+    const matches = candidates.filter((opt) => {
+      const spec = ctx.resultPool.getPColumnSpecByRef(opt.ref);
+      const rowAxis = spec?.axesSpec?.[1];
+      if (!rowAxis || !isClonotypeAxis(rowAxis.name)) return false;
+      const candidateKey = JSON.stringify(
+        Object.entries(rowAxis.domain ?? {}).sort(([a], [b]) => a.localeCompare(b)),
+      );
+      return candidateKey === identityKey;
+    });
+
+    // Exactly one is expected; anything else → no column (don't guess).
+    return matches.length === 1 ? matches[0].ref : undefined;
   })
 
   /** PFrame with condition column and (when antigen enabled) antigen column for UI to fetch metadata values. */

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -97,8 +97,9 @@ export type BlockData = {
   FilteringConfig: FilteringConfig;
   clonotypeDefinition: SUniversalPColumnId[];
   /**
-   * Cluster-mode only: PlRef of the upstream per-clonotype primary abundance the
-   * input cluster abundance was built from.
+   * Cluster-mode only: PlRef of the upstream per-element primary abundance the
+   * input cluster abundance was built from (per clonotype for VDJ clusters, per
+   * variant for peptide clusters).
    */
   clonotypeAbundanceRef?: PlRef;
   additionalEnrichmentExports: string[];
@@ -304,9 +305,10 @@ export const platforma = BlockModelV3.create(dataModel)
   })
 
   /**
-   * Cluster-mode only: identify the upstream per-clonotype primary abundance that
-   * the input cluster abundance was built from. Returns undefined for
-   * clonotype/peptide input or when no unique match exists.
+   * Cluster-mode only: identify the upstream per-element primary abundance (per
+   * clonotype for VDJ clusters, per variant for peptide clusters) that the input
+   * cluster abundance was built from. Returns undefined for clonotype/peptide
+   * input or when no unique match exists.
    */
   .output("discoveredClonotypeAbundance", (ctx) => {
     const anchor = ctx.data.abundanceRef;
@@ -325,8 +327,12 @@ export const platforma = BlockModelV3.create(dataModel)
         .sort(([a], [b]) => a.localeCompare(b)),
     );
 
-    const isClonotypeAxis = (name: string) =>
-      name === "pl7.app/vdj/clonotypeKey" || name === "pl7.app/vdj/scClonotypeKey";
+    // The per-element row axis can be a clonotype key (VDJ clusters) or a
+    // variant key (peptide clusters).
+    const isElementAxis = (name: string) =>
+      name === "pl7.app/vdj/clonotypeKey" ||
+      name === "pl7.app/vdj/scClonotypeKey" ||
+      name === "pl7.app/variantKey";
 
     // Candidate primary, raw-count abundances keyed by sampleId × <row axis>.
     const candidates = ctx.resultPool.getOptions([
@@ -344,7 +350,7 @@ export const platforma = BlockModelV3.create(dataModel)
     const matches = candidates.filter((opt) => {
       const spec = ctx.resultPool.getPColumnSpecByRef(opt.ref);
       const rowAxis = spec?.axesSpec?.[1];
-      if (!rowAxis || !isClonotypeAxis(rowAxis.name)) return false;
+      if (!rowAxis || !isElementAxis(rowAxis.name)) return false;
       const candidateKey = JSON.stringify(
         Object.entries(rowAxis.domain ?? {}).sort(([a], [b]) => a.localeCompare(b)),
       );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,11 +28,11 @@ catalogs:
       specifier: 1.6.6
       version: 1.6.6
     '@platforma-sdk/block-tools':
-      specifier: 2.11.1
-      version: 2.11.1
+      specifier: 2.11.2
+      version: 2.11.2
     '@platforma-sdk/model':
-      specifier: 1.79.15
-      version: 1.79.15
+      specifier: 1.79.17
+      version: 1.79.17
     '@platforma-sdk/package-builder':
       specifier: 3.13.0
       version: 3.13.0
@@ -40,14 +40,14 @@ catalogs:
       specifier: 4.0.9
       version: 4.0.9
     '@platforma-sdk/test':
-      specifier: 1.79.15
-      version: 1.79.15
+      specifier: 1.79.18
+      version: 1.79.18
     '@platforma-sdk/ui-vue':
-      specifier: 1.79.15
-      version: 1.79.15
+      specifier: 1.79.17
+      version: 1.79.17
     '@platforma-sdk/workflow-tengo':
-      specifier: 6.6.3
-      version: 6.6.3
+      specifier: 6.6.5
+      version: 6.6.5
     '@vueuse/core':
       specifier: ^13.3.0
       version: 13.9.0
@@ -92,7 +92,7 @@ importers:
         version: 1.5.2(@types/node@24.5.2)(rollup@4.52.0)(sass-embedded@1.89.0)(vue@3.5.26(typescript@5.6.3))(yaml@2.8.2)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.11.1(@types/node@24.5.2)
+        version: 2.11.2(@types/node@24.5.2)
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -117,7 +117,7 @@ importers:
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.11.1(@types/node@24.5.2)
+        version: 2.11.2(@types/node@24.5.2)
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -126,13 +126,13 @@ importers:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.2(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.15)(@platforma-sdk/ui-vue@1.79.15(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
+        version: 1.4.2(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.17)(@platforma-sdk/ui-vue@1.79.17(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
       '@milaboratories/helpers':
         specifier: 'catalog:'
         version: 1.14.2
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.15
+        version: 1.79.17
       '@types/node':
         specifier: '*'
         version: 24.5.2
@@ -148,7 +148,7 @@ importers:
         version: 1.2.3
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.11.1(@types/node@24.5.2)
+        version: 2.11.2(@types/node@24.5.2)
       eslint:
         specifier: 'catalog:'
         version: 9.39.2
@@ -179,7 +179,7 @@ importers:
         version: 1.2.3
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.79.15(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@6.4.1(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.0)(yaml@2.8.2))
+        version: 1.79.18(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@6.4.1(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
         version: 4.0.16(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.0)(yaml@2.8.2)
@@ -188,16 +188,16 @@ importers:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.2(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.15)(@platforma-sdk/ui-vue@1.79.15(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
+        version: 1.4.2(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.17)(@platforma-sdk/ui-vue@1.79.17(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
       '@platforma-open/milaboratories.clonotype-enrichment.model':
         specifier: workspace:*
         version: link:../model
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.15
+        version: 1.79.17
       '@platforma-sdk/ui-vue':
         specifier: 'catalog:'
-        version: 1.79.15(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
+        version: 1.79.17(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
       '@types/node':
         specifier: '*'
         version: 24.5.2
@@ -231,7 +231,7 @@ importers:
         version: link:../software
       '@platforma-sdk/workflow-tengo':
         specifier: 'catalog:'
-        version: 6.6.3
+        version: 6.6.5
     devDependencies:
       '@platforma-open/milaboratories.software-ptransform':
         specifier: 'catalog:'
@@ -241,7 +241,7 @@ importers:
         version: 4.0.9
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.79.15(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.0)(yaml@2.8.2))
+        version: 1.79.18(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.0)(yaml@2.8.2))
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -1145,8 +1145,8 @@ packages:
   '@milaboratories/miplots4@1.2.0':
     resolution: {integrity: sha512-tUJkqB6yCj/HxSrxWvmiCulluPwhIy1538e93cz/P9t2OqAXCumkyGbXwNKwwSRxitiVVjqG26rZbMQBctykdA==}
 
-  '@milaboratories/pf-driver@1.7.12':
-    resolution: {integrity: sha512-/GoaeSW5v3Sfq2Du6qbN4WoBEDiMDPzE3GiF5a+85ZGbGS59tyenfALRZ4MUzpOlFK61zjxdrhdsaLJ4vYk6JA==}
+  '@milaboratories/pf-driver@1.7.13':
+    resolution: {integrity: sha512-p+TyMp6yy1BYj+2V4GknhBIZSlHSy0BeBGRINc4D1UkNwl/pliuK2Ry9qKOWk1x/BW1zIG0Maho1uGwsrJvV9A==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pf-plots@1.4.1':
@@ -1155,25 +1155,25 @@ packages:
       '@milaboratories/pl-model-common': 1.39.0
       '@platforma-sdk/model': 1.73.3
 
-  '@milaboratories/pf-spec-driver@1.4.14':
-    resolution: {integrity: sha512-APmMSE0phanFF/i2RWuugNMFAO+ubY03B0kGzmoOd5BvxO8TJ1rFXMxYU3NoyBrELMnRUMpZlqRKesrp0F5MDg==}
+  '@milaboratories/pf-spec-driver@1.4.15':
+    resolution: {integrity: sha512-jqqEO3bJ42///g8NOatXcPk7DatZ5xgFRNdpIhiiht81trZ2mF+diSkLBKRrU2hmiywSMm6iI8YmUQAfyy3Euw==}
 
-  '@milaboratories/pframes-rs-node@1.1.50':
-    resolution: {integrity: sha512-XshCE3Z9+tAKszlWCSDYJnpYRTIsag8v3YcjPmP6//W3dXDDrqi6gBqaGI0u58V9C3PLCjP3zC85vmtI5L26BQ==}
+  '@milaboratories/pframes-rs-node@1.1.52':
+    resolution: {integrity: sha512-Uu4KsQx0GiKvFASI+Cm0nMCMieUVo35mpz4j8mYUYImr7S+bVDDcHweCWrkLkSeImnOQnYHVo9RycViG6QwUQw==}
 
-  '@milaboratories/pframes-rs-serv@1.1.50':
-    resolution: {integrity: sha512-XFWRsTGLCfQZhpRlWAmmBfznWyKL72dXY8UFTK+gmI2SOFdxQb8CJc0v/6LgNohwTKRTZZr59K9eRP3v8gCK6A==}
+  '@milaboratories/pframes-rs-serv@1.1.52':
+    resolution: {integrity: sha512-yVfcyLztgj5UAffj30se5G4MwxkIOFVWPHY1tZZ8zLhQQzx95R/e1toAqq3FLV7y6kpJovwmLusbefgKw9Ejcg==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasip2@1.1.50':
-    resolution: {integrity: sha512-FHv6Cksyl9q9plIhRUzNP0cQ03aZVltNh+haZ5KGVNHh9e5PgP9ndnTP06bQ1JRyQ/6Thf1NF5yw1lBXp6J+uw==}
+  '@milaboratories/pframes-rs-wasip2@1.1.52':
+    resolution: {integrity: sha512-0rb0We6Q/aqrHJ062dayvLb4RExODZdqfsVWdzeHq23alY5TjJRMWsO9aKQpPnOuUKjAimdjlp+Ldq9TVhbEtg==}
 
-  '@milaboratories/pframes-rs-wasm@1.1.50':
-    resolution: {integrity: sha512-D7YvFltjAk+OLCC/5/U741Hipxof4v/t0cJbk+y38MJjx6PyGQhAyVP/J4XfbJgdFdTGdDidRCNGYLt/Jn8l3w==}
+  '@milaboratories/pframes-rs-wasm@1.1.52':
+    resolution: {integrity: sha512-Wn8/LJxcsvWSSpdymdebWrBnmgu9wAbzvOiHCtXz7Aqt1M2T8Xp9a7CprzCYx+EvhSuAuoxbq6naxkPsQrbkvg==}
     peerDependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
-      '@milaboratories/pl-model-common': 1.46.1
-      '@milaboratories/pl-model-middle-layer': 1.30.5
+      '@milaboratories/pl-model-common': 1.46.2
+      '@milaboratories/pl-model-middle-layer': 1.30.7
 
   '@milaboratories/pl-client@3.11.5':
     resolution: {integrity: sha512-8ftoKYPwL+s6f5j7psXxgHTkZBgexvtr+sBish1XR71J3Vgdc6edNJvlcFjtTexu91CWoAex1psp5WTZYnnE8g==}
@@ -1203,24 +1203,21 @@ packages:
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-middle-layer@1.64.33':
-    resolution: {integrity: sha512-4tUGPuFFyOQJiM1JQuXZeWNYU0CU5DD1Z5yd/bBrn6Vwi0itO5NuEUms5DrbPdXAdEMGVoYRJGSRaqapTHDcjA==}
+  '@milaboratories/pl-middle-layer@1.64.36':
+    resolution: {integrity: sha512-49Y8Kxjx3uFoXuX4H3Rkd50KXZtmedYJQQDit63wp/AZ0JdvxODqvThdAfvezGtVVHf5gBhxo4HvTJml7t9PIg==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-model-backend@1.4.8':
     resolution: {integrity: sha512-1MD6WZR9f0DPYMfaU/iFf3LYByWu8IWCCXNDDC+ARSlSAvi/aVImoowUmxlxB5cOgSbjPHmw+QIUVkB5oSC0wg==}
 
-  '@milaboratories/pl-model-common@1.46.1':
-    resolution: {integrity: sha512-ABOz/w7dA4t2zUpZHXI74MTNW6LmPFSLxgfhOPFdO6vodIY8draVN+ag2U21WlYIoSgdJwSXJrXJWdu1cefrIg==}
-
   '@milaboratories/pl-model-common@1.46.2':
     resolution: {integrity: sha512-VEeauisApYScvCS8lnK3zpFJ520xuTAodKJmjR8ulHcMrWMyWMfHEdGb7j5OMD0mM/OwTgmQrrJ5eB7Xd+xoOQ==}
 
-  '@milaboratories/pl-model-middle-layer@1.30.5':
-    resolution: {integrity: sha512-TSpemA65REZay1ObnuwV3QLIjN46Iluy0HUu/aiHMQ1d1BFAG2vrgvonQqTnxp7UKQYOr9RGJg/QDYG/+UNKMw==}
-
   '@milaboratories/pl-model-middle-layer@1.30.7':
     resolution: {integrity: sha512-rs9x3Ron4ujR/UOdEgB8WUB1SvZ8ZAScT1Av/e4or+iiQ/CzhmK9nqtYamHVwKV+JgwIFbXQwxGvIHDVz955dQ==}
+
+  '@milaboratories/pl-model-middle-layer@1.30.8':
+    resolution: {integrity: sha512-TH5kYb8YN40QaZYAVf2+hrNgAIMbJamk0GH7GaHEHdbsEkKLyuZcyz//zXaDEo/m9ACuI6yHC1ULBymL3p73Sg==}
 
   '@milaboratories/pl-tree@1.12.13':
     resolution: {integrity: sha512-ub/YLAzvTOs6QzSg0H/+luZ/7AHqsM+mte7SUNjivJBbC5OFMVcNeyQrLKjKu2JETRFAxIHv/qMQMnLbsdK2Lw==}
@@ -1254,8 +1251,8 @@ packages:
     resolution: {integrity: sha512-HK3AmNZl2fOzMHot2+ihKsOC+fluwhl5261VTn1zGS3LRpmC9bCk/po8SzsVmg79ccI5nESFTdz+BRaLsXncmQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/uikit@2.15.9':
-    resolution: {integrity: sha512-YVdVGBs/MaZTbzjidhIWi8lgrIpdtMEZKgjHEkqM2pknJFdisRXV6w24Hi/aUMA8pgYdCcR113eukv64c/grLg==}
+  '@milaboratories/uikit@2.15.10':
+    resolution: {integrity: sha512-y8Va+PkJTD5itT9LEPJyHx9ZINDtjlGH4w5MnESOvHJOH2UbYKhr2xbsuYQZQyAuNUO9Il7hBbudPKNIRrCT5A==}
 
   '@napi-rs/wasm-runtime@1.1.3':
     resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
@@ -1577,8 +1574,8 @@ packages:
   '@platforma-open/milaboratories.software-ptabler.schema@1.15.15':
     resolution: {integrity: sha512-zvPuRZgQyxjED+txJVgWHUOPeRp4TG1jOrJOtuw9WnwxFiHNjQHIB+Xe1j8f6skgMqZgRSQvEbhRvqbWjGmhKQ==}
 
-  '@platforma-open/milaboratories.software-ptabler@2.1.2':
-    resolution: {integrity: sha512-pCPA9oa4MPZ8mw7tJRjp4Zy9e/xJL9+tWKlSVXd+PbSkAqZoPTirf1izWV/NEZhhM7w8przq4jGhbqj6ukkCRQ==}
+  '@platforma-open/milaboratories.software-ptabler@2.1.3':
+    resolution: {integrity: sha512-4cikdkdJ5WYc0Nw3IoZxzlFNKvG1qCAqSjypq5b18pIK6LBDayzhFcuw5TDd8O3bAFhoHP+3cVTmoO9XUTYMRg==}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.2':
     resolution: {integrity: sha512-I08YpKQ4+esLrfpVra5UJ+bznI9Zzba6OW0rKK407a1EUmanvYMVrCbM9gqnm6CHbv2vQxNGSaO8p1LoBh+9gA==}
@@ -1604,16 +1601,16 @@ packages:
   '@platforma-open/milaboratories.software-small-binaries@2.1.1':
     resolution: {integrity: sha512-KN1PR7YgUUfx1dxh/TtcoWpSZbOXbRxXzQuJ505qHuXuE0spYwC7bXnvJsEYbEwRcPMa0foTrjBnPNORE4yr+Q==}
 
-  '@platforma-sdk/block-tools@2.11.1':
-    resolution: {integrity: sha512-YMD/BtpJPqhyoxKWvgkWJisQE8vVmp2R62BWPjoPB6VRbKF8k3tfXV28AcMQl2tpR/LJ6o58qPaap5KB5qAYxw==}
+  '@platforma-sdk/block-tools@2.11.2':
+    resolution: {integrity: sha512-GdT7IR5PSLFGvbKcns1wlGci/A+GrU/A6lyDxp8AhxryolzmGY8vQoEU+jkU6tDWOw/fRwo14+o3hCNqsZ8AGA==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
     resolution: {integrity: sha512-p9lBxhFXM9WoRsrJO7dfkiXSK+1m63yIn1sKhBO71eMbhrLMyVYHEOeNf3w5OCdbRF5QsNhXzWuiTmFK3zHFsA==}
     hasBin: true
 
-  '@platforma-sdk/model@1.79.15':
-    resolution: {integrity: sha512-3NT5XUmFQzxaDNC4OWHLOgDi+w0HVhoDHbu/WVXw1L9wKRovYkksJsQSZQ91pd+ah3WO8N9T/CeAj6knWEYMAA==}
+  '@platforma-sdk/model@1.79.17':
+    resolution: {integrity: sha512-EGSNAkfchxRnKcuaudYlNoHQgZqRMqI6AZ54pdscjppssscZOPHcv90ytmbBfXAANhykOCKJS9zx2JgmfUQtSQ==}
 
   '@platforma-sdk/package-builder@3.13.0':
     resolution: {integrity: sha512-5dMFx1S8cotsWd9rccJlyRH00j43f9JFzLmuMGqwKCdfv+T0TADBWvbFRv1oD+kr5gRGj++Ud5GUIVVUUr6suw==}
@@ -1624,14 +1621,14 @@ packages:
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/test@1.79.15':
-    resolution: {integrity: sha512-fHKAyipDuZUdBjJN5SEEDR3YHOUKkdcYKS9aEWPxN/iCk0GzoMB1MbbOELY5UmeFK9frXvpojfJ9sgBCJzbSPg==}
+  '@platforma-sdk/test@1.79.18':
+    resolution: {integrity: sha512-gRWAQsAV6ji9mVtgSi+Wzom9u8acAyt7mSNsCfb8fsx/aWaqhSoyNmOJEgGQuXizm7Bpo/2Ah+m3bnaonyKCtA==}
 
-  '@platforma-sdk/ui-vue@1.79.15':
-    resolution: {integrity: sha512-1/yWw5Pj5Muh1mb2gwRvde7R+L4uoO+nRjayRrkLxGso0SMnKkECCds2ZFduFTDE8qY73c9VI+6BDAxyF8iFfA==}
+  '@platforma-sdk/ui-vue@1.79.17':
+    resolution: {integrity: sha512-h1OiX9UzT1dnR0Dz+Bpo63IYUW32OjT0X6PBXa+fVD7OEF3biwxPASqRBBNluH4yj6f/GBPDhLeWuU74252CgQ==}
 
-  '@platforma-sdk/workflow-tengo@6.6.3':
-    resolution: {integrity: sha512-2H83hEd+t8pIcSpz0anmWb0wesEcoXCYl9HSOcfQL9b0ro6EDf+PwyafXtmbXl2kMtkpccigbhDGZdDhoMpr7w==}
+  '@platforma-sdk/workflow-tengo@6.6.5':
+    resolution: {integrity: sha512-BIY0DongPruQ7e2EMYy2b0UtO5ziGcLvr2RWgJ8ki17VKNzW3esm/RBszGHMrTYmXM0Yw7mCSasor4vH560g7A==}
 
   '@protobuf-ts/grpc-transport@2.11.1':
     resolution: {integrity: sha512-l6wrcFffY+tuNnuyrNCkRM8hDIsAZVLA8Mn7PKdVyYxITosYh60qW663p9kL6TWXYuDCL3oxH8ih3vLKTDyhtg==}
@@ -7882,14 +7879,14 @@ snapshots:
       '@types/node': 24.5.2
       utility-types: 3.11.0
 
-  '@milaboratories/graph-maker@1.4.2(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.15)(@platforma-sdk/ui-vue@1.79.15(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)':
+  '@milaboratories/graph-maker@1.4.2(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.17)(@platforma-sdk/ui-vue@1.79.17(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)':
     dependencies:
       '@ag-grid-community/core': 32.3.9
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/miplots4': 1.2.0(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.1(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.15)
-      '@platforma-sdk/model': 1.79.15
-      '@platforma-sdk/ui-vue': 1.79.15(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
+      '@milaboratories/pf-plots': 1.4.1(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.17)
+      '@platforma-sdk/model': 1.79.17
+      '@platforma-sdk/ui-vue': 1.79.17(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
       '@types/d3-hierarchy': 3.1.7
       '@types/d3-scale': 4.0.9
       '@vueuse/core': 13.9.0(vue@3.5.26(typescript@5.9.3))
@@ -7946,13 +7943,13 @@ snapshots:
       - d3-scale-chromatic
       - supports-color
 
-  '@milaboratories/pf-driver@1.7.12(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pf-driver@1.7.13(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-node': 1.1.50
-      '@milaboratories/pframes-rs-wasm': 1.1.50(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.2)(@milaboratories/pl-model-middle-layer@1.30.7)
+      '@milaboratories/pframes-rs-node': 1.1.52
+      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.2)(@milaboratories/pl-model-middle-layer@1.30.8)
       '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.7
+      '@milaboratories/pl-model-middle-layer': 1.30.8
       '@milaboratories/ts-helpers': 1.8.3
       es-toolkit: 1.39.10
       lru-cache: 11.2.4
@@ -7961,52 +7958,52 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pf-plots@1.4.1(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.15)':
+  '@milaboratories/pf-plots@1.4.1(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.17)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-model-common': 1.46.2
-      '@platforma-sdk/model': 1.79.15
+      '@platforma-sdk/model': 1.79.17
       canonicalize: 2.1.0
       lodash: 4.17.21
 
-  '@milaboratories/pf-spec-driver@1.4.14(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pf-spec-driver@1.4.15(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-wasm': 1.1.50(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.2)(@milaboratories/pl-model-middle-layer@1.30.7)
+      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.2)(@milaboratories/pl-model-middle-layer@1.30.8)
       '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.7
+      '@milaboratories/pl-model-middle-layer': 1.30.8
       '@noble/hashes': 2.0.1
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
 
-  '@milaboratories/pframes-rs-node@1.1.50':
+  '@milaboratories/pframes-rs-node@1.1.52':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-serv': 1.1.50
-      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pframes-rs-serv': 1.1.52
+      '@milaboratories/pl-model-common': 1.46.2
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.50':
+  '@milaboratories/pframes-rs-serv@1.1.52':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.46.1
-      '@milaboratories/pl-model-middle-layer': 1.30.5
+      '@milaboratories/pl-model-common': 1.46.2
+      '@milaboratories/pl-model-middle-layer': 1.30.7
       better-sqlite3: 12.10.0
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasip2@1.1.50': {}
+  '@milaboratories/pframes-rs-wasip2@1.1.52': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.50(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.2)(@milaboratories/pl-model-middle-layer@1.30.7)':
+  '@milaboratories/pframes-rs-wasm@1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.2)(@milaboratories/pl-model-middle-layer@1.30.8)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pframes-rs-wasip2': 1.1.50
+      '@milaboratories/pframes-rs-wasip2': 1.1.52
       '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.7
+      '@milaboratories/pl-model-middle-layer': 1.30.8
 
   '@milaboratories/pl-client@3.11.5':
     dependencies:
@@ -8095,14 +8092,14 @@ snapshots:
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-middle-layer@1.64.33(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)':
+  '@milaboratories/pl-middle-layer@1.64.36(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)':
     dependencies:
       '@milaboratories/computable': 2.9.5
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pf-driver': 1.7.12(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pf-spec-driver': 1.4.14(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pframes-rs-node': 1.1.50
-      '@milaboratories/pframes-rs-wasm': 1.1.50(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.2)(@milaboratories/pl-model-middle-layer@1.30.7)
+      '@milaboratories/pf-driver': 1.7.13(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pf-spec-driver': 1.4.15(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pframes-rs-node': 1.1.52
+      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.2)(@milaboratories/pl-model-middle-layer@1.30.8)
       '@milaboratories/pl-client': 3.11.5
       '@milaboratories/pl-deployments': 3.0.8
       '@milaboratories/pl-drivers': 1.16.1
@@ -8110,13 +8107,13 @@ snapshots:
       '@milaboratories/pl-http': 1.2.4
       '@milaboratories/pl-model-backend': 1.4.8
       '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.7
+      '@milaboratories/pl-model-middle-layer': 1.30.8
       '@milaboratories/pl-tree': 1.12.13
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.3
-      '@platforma-sdk/block-tools': 2.11.1(@types/node@24.5.2)
-      '@platforma-sdk/model': 1.79.15
-      '@platforma-sdk/workflow-tengo': 6.6.3
+      '@platforma-sdk/block-tools': 2.11.2(@types/node@24.5.2)
+      '@platforma-sdk/model': 1.79.17
+      '@platforma-sdk/workflow-tengo': 6.6.5
       canonicalize: 2.1.0
       denque: 2.1.0
       es-toolkit: 1.39.10
@@ -8142,13 +8139,6 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-common@1.46.1':
-    dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-error-like': 1.12.10
-      canonicalize: 2.1.0
-      zod: 3.25.76
-
   '@milaboratories/pl-model-common@1.46.2':
     dependencies:
       '@milaboratories/helpers': 1.14.2
@@ -8156,15 +8146,15 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.30.5':
+  '@milaboratories/pl-model-middle-layer@1.30.7':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pl-model-common': 1.46.2
       es-toolkit: 1.39.10
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.30.7':
+  '@milaboratories/pl-model-middle-layer@1.30.8':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-model-common': 1.46.2
@@ -8328,10 +8318,10 @@ snapshots:
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/uikit@2.15.9(typescript@5.9.3)':
+  '@milaboratories/uikit@2.15.10(typescript@5.9.3)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@platforma-sdk/model': 1.79.15
+      '@platforma-sdk/model': 1.79.17
       '@types/d3-array': 3.2.2
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -8636,7 +8626,7 @@ snapshots:
     dependencies:
       '@milaboratories/pl-model-common': 1.46.2
 
-  '@platforma-open/milaboratories.software-ptabler@2.1.2': {}
+  '@platforma-open/milaboratories.software-ptabler@2.1.3': {}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.2': {}
 
@@ -8660,14 +8650,14 @@ snapshots:
       '@platforma-open/milaboratories.software-small-binaries.mnz-client': 1.6.5
       '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.5
 
-  '@platforma-sdk/block-tools@2.11.1(@types/node@24.5.2)':
+  '@platforma-sdk/block-tools@2.11.2(@types/node@24.5.2)':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@inquirer/prompts': 7.10.1(@types/node@24.5.2)
       '@milaboratories/pl-http': 1.2.4
       '@milaboratories/pl-model-backend': 1.4.8
       '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.7
+      '@milaboratories/pl-model-middle-layer': 1.30.8
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.3
       '@milaboratories/ts-helpers-oclif': 1.1.42
@@ -8688,12 +8678,12 @@ snapshots:
     dependencies:
       yaml: 2.8.2
 
-  '@platforma-sdk/model@1.79.15':
+  '@platforma-sdk/model@1.79.17':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-error-like': 1.12.10
       '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.7
+      '@milaboratories/pl-model-middle-layer': 1.30.8
       '@milaboratories/ptabler-expression-js': 1.2.31
       canonicalize: 2.1.0
       es-toolkit: 1.39.10
@@ -8727,13 +8717,13 @@ snapshots:
       '@oclif/core': 4.8.0
       winston: 3.17.0
 
-  '@platforma-sdk/test@1.79.15(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@6.4.1(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.0)(yaml@2.8.2))':
+  '@platforma-sdk/test@1.79.18(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@6.4.1(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.0)(yaml@2.8.2))':
     dependencies:
       '@milaboratories/computable': 2.9.5
       '@milaboratories/pl-client': 3.11.5
-      '@milaboratories/pl-middle-layer': 1.64.33(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
+      '@milaboratories/pl-middle-layer': 1.64.36(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
       '@milaboratories/pl-tree': 1.12.13
-      '@platforma-sdk/model': 1.79.15
+      '@platforma-sdk/model': 1.79.17
       '@vitest/coverage-istanbul': 4.1.4(vitest@4.0.16(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.0)(yaml@2.8.2))
       vitest: 4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4)(vite@6.4.1(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.0)(yaml@2.8.2))
     transitivePeerDependencies:
@@ -8756,13 +8746,13 @@ snapshots:
       - supports-color
       - vite
 
-  '@platforma-sdk/test@1.79.15(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.0)(yaml@2.8.2))':
+  '@platforma-sdk/test@1.79.18(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.0)(yaml@2.8.2))':
     dependencies:
       '@milaboratories/computable': 2.9.5
       '@milaboratories/pl-client': 3.11.5
-      '@milaboratories/pl-middle-layer': 1.64.33(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
+      '@milaboratories/pl-middle-layer': 1.64.36(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
       '@milaboratories/pl-tree': 1.12.13
-      '@platforma-sdk/model': 1.79.15
+      '@platforma-sdk/model': 1.79.17
       '@vitest/coverage-istanbul': 4.1.4(vitest@4.1.4)
       vitest: 4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.0)(yaml@2.8.2))
     transitivePeerDependencies:
@@ -8785,12 +8775,12 @@ snapshots:
       - supports-color
       - vite
 
-  '@platforma-sdk/ui-vue@1.79.15(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
+  '@platforma-sdk/ui-vue@1.79.17(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
     dependencies:
-      '@milaboratories/pf-spec-driver': 1.4.14(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pf-spec-driver': 1.4.15(@bytecodealliance/preview2-shim@0.17.8)
       '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/uikit': 2.15.9(typescript@5.9.3)
-      '@platforma-sdk/model': 1.79.15
+      '@milaboratories/uikit': 2.15.10(typescript@5.9.3)
+      '@platforma-sdk/model': 1.79.17
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.1
@@ -8821,11 +8811,11 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@platforma-sdk/workflow-tengo@6.6.3':
+  '@platforma-sdk/workflow-tengo@6.6.5':
     dependencies:
-      '@milaboratories/pframes-rs-wasip2': 1.1.50
+      '@milaboratories/pframes-rs-wasip2': 1.1.52
       '@milaboratories/software-pframes-conv': 2.2.9
-      '@platforma-open/milaboratories.software-ptabler': 2.1.2
+      '@platforma-open/milaboratories.software-ptabler': 2.1.3
       '@platforma-open/milaboratories.software-ptexter': 1.2.2
       '@platforma-open/milaboratories.software-small-binaries': 2.1.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,13 +10,13 @@ catalog:
   # SDK packages - EXACT VERSIONS (no ^ or ~)
   '@milaboratories/ts-builder': 1.5.2
   '@milaboratories/ts-configs': 1.2.3
-  '@platforma-sdk/workflow-tengo': 6.6.3
-  '@platforma-sdk/model': 1.79.15
-  '@platforma-sdk/ui-vue': 1.79.15
+  '@platforma-sdk/workflow-tengo': 6.6.5
+  '@platforma-sdk/model': 1.79.17
+  '@platforma-sdk/ui-vue': 1.79.17
   '@platforma-sdk/tengo-builder': 4.0.9
   '@platforma-sdk/package-builder': 3.13.0
-  '@platforma-sdk/block-tools': 2.11.1
-  '@platforma-sdk/test': 1.79.15
+  '@platforma-sdk/block-tools': 2.11.2
+  '@platforma-sdk/test': 1.79.18
   '@milaboratories/helpers': 1.14.2
 
   # Block-specific dependencies

--- a/software/package.json
+++ b/software/package.json
@@ -90,6 +90,24 @@
             "{pkg}/downsampling.py"
           ]
         }
+      },
+      "clonotype-max-frequency": {
+        "binary": {
+          "artifact": {
+            "type": "python",
+            "registry": "platforma-open",
+            "environment": "@platforma-open/milaboratories.runenv-python-3:3.12.10",
+            "dependencies": {
+              "toolset": "pip",
+              "requirements": "requirements.txt"
+            },
+            "root": "./src"
+          },
+          "cmd": [
+            "python",
+            "{pkg}/clonotype_max_frequency.py"
+          ]
+        }
       }
     }
   }

--- a/software/src/clonotype_max_frequency.py
+++ b/software/src/clonotype_max_frequency.py
@@ -1,0 +1,124 @@
+"""
+Per-clonotype maximum frequency across target selection rounds.
+
+Used when the enrichment block input is *cluster* abundance: the enrichment
+analysis runs at cluster resolution, but Lead Selection ranks individual
+clonotypes, so we surface each clonotype's own max frequency as a score.
+
+Frequency is computed with the SAME definition the main enrichment script uses
+for its per-condition frequencies (downsampled abundance + pseudo-count
+normalization), so the two are comparable:
+
+    freq_c = (abundance_c + p) / (total_c + N * p)
+
+where, for the target track:
+  - abundance_c : the clonotype's summed (downsampled) abundance in condition c
+  - total_c     : total reads in condition c
+  - N           : number of clonotypes in the track
+  - p           : pseudo-count
+
+The "target track" excludes the library round and negative controls: when an
+antigen column is present we keep only rows of the current target antigen
+(library and negative-control samples carry different antigen values). The max
+is taken over the target condition order only.
+
+Input CSV (the downsampling output) columns:
+    sampleId, elementId, abundance, downsampledAbundance, condition, [antigen]
+Output CSV columns:
+    elementId, MaxFrequency
+"""
+import argparse
+import json
+
+import polars as pl
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Per-clonotype max frequency across target rounds")
+    parser.add_argument("--input_data", required=True,
+                        help="Downsampling output CSV (clonotype resolution).")
+    parser.add_argument("--conditions", type=str, required=True,
+                        help="JSON list of target conditions (rounds), ordered.")
+    parser.add_argument("--pseudo_count", type=int, default=1)
+    parser.add_argument("--current_target", type=str, default=None,
+                        help="Target antigen value; when set, only its rows are "
+                             "used (excludes library and negative controls).")
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    condition_order = [str(c) for c in json.loads(args.conditions)]
+    pseudo = args.pseudo_count
+
+    empty = pl.DataFrame(schema={"elementId": pl.Utf8, "MaxFrequency": pl.Float64})
+
+    df = pl.read_csv(args.input_data, schema_overrides={"condition": pl.Utf8})
+
+    # Use the downsampled abundance, matching the main enrichment script
+    # (enrichment.py renames downsampledAbundance -> abundance before use).
+    if "downsampledAbundance" in df.columns:
+        if "abundance" in df.columns:
+            df = df.drop("abundance")
+        df = df.rename({"downsampledAbundance": "abundance"})
+
+    if df.height == 0:
+        empty.write_csv(args.output)
+        return
+
+    df = df.with_columns(
+        pl.col("abundance").cast(pl.Float64),
+        pl.col("condition").cast(pl.Utf8),
+    )
+
+    # Restrict to the target track: keep only the current target antigen's rows.
+    # Library and negative-control samples carry other antigen values and are
+    # dropped here, so they never contribute to the max frequency.
+    if args.current_target is not None and "antigen" in df.columns:
+        df = df.filter(pl.col("antigen").cast(pl.Utf8) == str(args.current_target))
+
+    if df.height == 0:
+        empty.write_csv(args.output)
+        return
+
+    # Sum (downsampled) abundance per clonotype per condition across samples.
+    agg = (
+        df.group_by(["elementId", "condition"])
+        .agg(pl.col("abundance").sum().alias("abundance"))
+    )
+
+    # Track-level totals and clonotype count for the normalization denominator.
+    totals_df = agg.group_by("condition").agg(pl.col("abundance").sum().alias("total"))
+    totals = dict(zip(totals_df["condition"].to_list(), totals_df["total"].to_list()))
+    n_clonotypes = agg.select("elementId").n_unique()
+
+    pivot = (
+        agg.pivot(values="abundance", index="elementId", on="condition",
+                  aggregate_function="sum")
+        .fill_null(0)
+    )
+
+    # Per-condition frequency, then max across the target rounds only.
+    freq_cols = []
+    for c in condition_order:
+        if c not in pivot.columns:
+            pivot = pivot.with_columns(pl.lit(0).alias(c))
+        total = totals.get(c, 1)
+        denom = total + (n_clonotypes * pseudo)
+        if denom <= 0:
+            denom = 1
+        freq_name = f"freq_{c}"
+        pivot = pivot.with_columns(
+            ((pl.col(c) + pseudo) / denom).alias(freq_name)
+        )
+        freq_cols.append(freq_name)
+
+    out = (
+        pivot.with_columns(pl.concat_list(freq_cols).list.max().alias("MaxFrequency"))
+        .select(["elementId", "MaxFrequency"])
+        .sort("elementId")
+    )
+    out.write_csv(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/software/src/clonotype_max_frequency.py
+++ b/software/src/clonotype_max_frequency.py
@@ -97,7 +97,7 @@ def main():
     freq_cols = []
     for c in condition_order:
         if c not in pivot.columns:
-            pivot = pivot.with_columns(pl.lit(0).alias(c))
+            pivot = pivot.with_columns(pl.lit(0.0).alias(c))
         total = totals.get(c, 0)
         freq_name = f"freq_{c}"
         if total > 0:

--- a/software/src/clonotype_max_frequency.py
+++ b/software/src/clonotype_max_frequency.py
@@ -5,17 +5,15 @@ Used when the enrichment block input is *cluster* abundance: the enrichment
 analysis runs at cluster resolution, but Lead Selection ranks individual
 clonotypes, so we surface each clonotype's own max frequency as a score.
 
-Frequency is computed with the SAME definition the main enrichment script uses
-for its per-condition frequencies (downsampled abundance + pseudo-count
-normalization), so the two are comparable:
+Frequency is the plain observed fraction (downsampled abundance over the round
+total), with no pseudo-count:
 
-    freq_c = (abundance_c + p) / (total_c + N * p)
+    freq_c = abundance_c / total_c       (absent round -> 0)
+    MaxFrequency = max over target rounds
 
-where, for the target track:
+Where:
   - abundance_c : the clonotype's summed (downsampled) abundance in condition c
-  - total_c     : total reads in condition c
-  - N           : number of clonotypes in the track
-  - p           : pseudo-count
+  - total_c     : total reads in condition c (target track)
 
 The "target track" excludes the library round and negative controls: when an
 antigen column is present we keep only rows of the current target antigen
@@ -40,7 +38,6 @@ def main():
                         help="Downsampling output CSV (clonotype resolution).")
     parser.add_argument("--conditions", type=str, required=True,
                         help="JSON list of target conditions (rounds), ordered.")
-    parser.add_argument("--pseudo_count", type=int, default=1)
     parser.add_argument("--current_target", type=str, default=None,
                         help="Target antigen value; when set, only its rows are "
                              "used (excludes library and negative controls).")
@@ -48,7 +45,6 @@ def main():
     args = parser.parse_args()
 
     condition_order = [str(c) for c in json.loads(args.conditions)]
-    pseudo = args.pseudo_count
 
     empty = pl.DataFrame(schema={"elementId": pl.Utf8, "MaxFrequency": pl.Float64})
 
@@ -86,10 +82,9 @@ def main():
         .agg(pl.col("abundance").sum().alias("abundance"))
     )
 
-    # Track-level totals and clonotype count for the normalization denominator.
+    # Total reads per target condition (denominator for the observed fraction).
     totals_df = agg.group_by("condition").agg(pl.col("abundance").sum().alias("total"))
     totals = dict(zip(totals_df["condition"].to_list(), totals_df["total"].to_list()))
-    n_clonotypes = agg.select("elementId").n_unique()
 
     pivot = (
         agg.pivot(values="abundance", index="elementId", on="condition",
@@ -97,19 +92,18 @@ def main():
         .fill_null(0)
     )
 
-    # Per-condition frequency, then max across the target rounds only.
+    # Observed per-condition frequency (reads / round total), then max across the
+    # target rounds.
     freq_cols = []
     for c in condition_order:
         if c not in pivot.columns:
             pivot = pivot.with_columns(pl.lit(0).alias(c))
-        total = totals.get(c, 1)
-        denom = total + (n_clonotypes * pseudo)
-        if denom <= 0:
-            denom = 1
+        total = totals.get(c, 0)
         freq_name = f"freq_{c}"
-        pivot = pivot.with_columns(
-            ((pl.col(c) + pseudo) / denom).alias(freq_name)
-        )
+        if total > 0:
+            pivot = pivot.with_columns((pl.col(c) / total).alias(freq_name))
+        else:
+            pivot = pivot.with_columns(pl.lit(0.0).alias(freq_name))
         freq_cols.append(freq_name)
 
     out = (

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -96,14 +96,12 @@ watchEffect(() => {
 });
 
 // Persist the auto-discovered per-clonotype abundance so the workflow can
-// compute the clonotype Max Frequency score. Only relevant for cluster input.
+// compute the clonotype Max Frequency score (cluster input only).
 watchEffect(() => {
   const datasetSpec = app.model.outputs.datasetSpec;
   const isCluster = datasetSpec?.axesSpec?.[1]?.name === "pl7.app/clusterId";
-  const current = app.model.data.clonotypeAbundanceRef;
   const next = isCluster ? app.model.outputs.discoveredClonotypeAbundance : undefined;
-  // In cluster mode keep a previously persisted ref while discovery recomputes.
-  if (isCluster && next === undefined) return;
+  const current = app.model.data.clonotypeAbundanceRef;
   if (JSON.stringify(current ?? null) !== JSON.stringify(next ?? null)) {
     app.model.data.clonotypeAbundanceRef = next;
   }

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -95,6 +95,20 @@ watchEffect(() => {
   app.model.data.defaultBlockLabel = label;
 });
 
+// Persist the auto-discovered per-clonotype abundance so the workflow can
+// compute the clonotype Max Frequency score. Only relevant for cluster input.
+watchEffect(() => {
+  const datasetSpec = app.model.outputs.datasetSpec;
+  const isCluster = datasetSpec?.axesSpec?.[1]?.name === "pl7.app/clusterId";
+  const current = app.model.data.clonotypeAbundanceRef;
+  const next = isCluster ? app.model.outputs.discoveredClonotypeAbundance : undefined;
+  // In cluster mode keep a previously persisted ref while discovery recomputes.
+  if (isCluster && next === undefined) return;
+  if (JSON.stringify(current ?? null) !== JSON.stringify(next ?? null)) {
+    app.model.data.clonotypeAbundanceRef = next;
+  }
+});
+
 const tableSettings = usePlDataTableSettingsV2({
   model: () => app.model.outputs.pt,
 });

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -434,7 +434,6 @@ wf.body(func(args) {
 			addFile("inputFile.csv", clonoDownsampling.getFile("result.csv")).
 			arg("--input_data").arg("inputFile.csv").
 			arg("--conditions").arg(string(conditionOrder)).
-			arg("--pseudo_count").arg(string(args.pseudoCount)).
 			arg("--output").arg("clonotype_max_frequency.csv")
 		if antigenControlConfig.antigenEnabled {
 			clonoMaxFreq = clonoMaxFreq.arg("--current_target").arg(string(antigenControlConfig.targetAntigen))

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -397,13 +397,17 @@ wf.body(func(args) {
 	exports := buildExports.output("exports")
 	outStats := buildExports.output("outStats")
 
-	//////////// Per-clonotype Max Frequency (cluster input only) ////////////
-	// Compute each clonotype's max frequency across target rounds (same
+	//////////// Per-element Max Frequency (cluster input only) ////////////
+	// Compute each element's max frequency across target rounds (same
 	// downsampling + frequency definition as the cluster-level frequencies) and
-	// export it on the clonotypeKey axis.
+	// export it on the per-element axis. The underlying element is a clonotype
+	// for VDJ clusters and a variant for peptide clusters.
 	clonotypeFrequencyExport := undefined
 	if inputType == "Cluster" && args.clonotypeAbundanceRef != undefined {
 		clonoAbundanceSpec := columns.getSpec(args.clonotypeAbundanceRef)
+
+		// Label the exported column after the underlying element type.
+		elementLabel := clonoAbundanceSpec.axesSpec[1].name == "pl7.app/variantKey" ? "Peptide" : "Clonotype"
 
 		clonoCloneTable := pframes.csvFileBuilder()
 		clonoCloneTable.add(columns.getColumn(args.clonotypeAbundanceRef), {header: "abundance"})
@@ -444,7 +448,7 @@ wf.body(func(args) {
 			saveStdoutContent().
 			run()
 
-		clonoFreqImportParams := pfClonotypeFrequencyConv.getColumns(clonoAbundanceSpec, downsampling, conditionOrder, blockId)
+		clonoFreqImportParams := pfClonotypeFrequencyConv.getColumns(clonoAbundanceSpec, downsampling, conditionOrder, blockId, elementLabel)
 		clonoFreqPf := xsv.importFile(clonoMaxFreq.getFile("clonotype_max_frequency.csv"), "csv", clonoFreqImportParams,
 			{ cpu: 1, mem: "16GiB" })
 
@@ -457,7 +461,7 @@ wf.body(func(args) {
 
 		clonoFreqExports := pframes.pFrameBuilder()
 		clonoFreqExports.add(
-			"Clonotype Max Frequency",
+			elementLabel + " Max Frequency",
 			clonoTrace.inject(clonoFreqPf["maxfrequency.spec"]),
 			clonoFreqPf["maxfrequency.data"]
 		)

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -13,12 +13,14 @@ text := import("text")
 buildMainExportTpl := assets.importTemplate(":build-main-export")
 enrichmentColumnTpl := assets.importTemplate(":enrichment-column")
 downsamplingSw := assets.importSoftware("@platforma-open/milaboratories.clonotype-enrichment.software:downsampling")
+clonotypeMaxFreqSw := assets.importSoftware("@platforma-open/milaboratories.clonotype-enrichment.software:clonotype-max-frequency")
 
 pfEnrichmentConv := import(":pf-enrichment-conv")
 pfFrequencyConv := import(":pf-frequency-conv")
 pfBubbleConv := import(":pf-bubble-conv")
 pfStackedConv := import(":pf-stacked-conv")
 pfControlScatterConv := import(":pf-control-scatter-conv")
+pfClonotypeFrequencyConv := import(":pf-clonotype-frequency-conv")
 
 // Helper function to calculate annotation values for enrichment data
 calculateAnnotationValues := func(inputFile, enrichmentColumn) {
@@ -29,7 +31,7 @@ calculateAnnotationValues := func(inputFile, enrichmentColumn) {
 		addFile("inputFile.csv", inputFile).
 		arg("inputFile.csv").
 		arg("--enrichment-column").arg(enrichmentColumn).
-		saveFileContent("enrichment_min.txt"). 
+		saveFileContent("enrichment_min.txt").
 		saveFileContent("enrichment_max.txt").
 		saveFileContent("enrichment_median.txt").
 		saveFileContent("enrichment_mean.txt").
@@ -52,7 +54,7 @@ calculateAnnotationValues := func(inputFile, enrichmentColumn) {
 wf.prepare(func(args){
 
 	bundleBuilder := wf.createPBundleBuilder()
-	bundleBuilder.addAnchor("main", args.abundanceRef) 
+	bundleBuilder.addAnchor("main", args.abundanceRef)
 	bundleBuilder.addSingle(args.conditionColumnRef)
 
 	if args.antigenControlConfig.antigenEnabled && args.antigenControlConfig.antigenColumnRef != undefined {
@@ -60,10 +62,17 @@ wf.prepare(func(args){
 	}
 
 	if args.clonotypeDefinition != undefined {
-        for columnRef in args.clonotypeDefinition {
-            bundleBuilder.addSingle(columnRef)
-        }
-    }
+		for columnRef in args.clonotypeDefinition {
+			bundleBuilder.addSingle(columnRef)
+		}
+	}
+
+	// Cluster mode: the per-clonotype primary abundance (a plain PlRef) the model
+	// matched to the input cluster abundance, used to compute the clonotype Max
+	// Frequency score.
+	if args.clonotypeAbundanceRef != undefined {
+		bundleBuilder.addRef(args.clonotypeAbundanceRef)
+	}
 
 	return {
 		columns: bundleBuilder.build()
@@ -100,7 +109,7 @@ wf.body(func(args) {
 	} else {
 		label = "Downsampling: " + downsampling.type
 	}
-	
+
 	// Add filtering mode to ensure cache differentiation
 	FilteringConfig := args.FilteringConfig
 	label = label + " - Filtering: " + FilteringConfig.baseFilter
@@ -110,7 +119,7 @@ wf.body(func(args) {
 	}
 
 	// Get abundance table
-	cloneTable := pframes.csvFileBuilder() 
+	cloneTable := pframes.csvFileBuilder()
 	cloneTable.add(columns.getColumn(args.abundanceRef), {header: "abundance"})
 	cloneTable.add(columns.getColumn(args.conditionColumnRef), {header: "condition"})
 	if antigenControlConfig.antigenEnabled {
@@ -123,16 +132,16 @@ wf.body(func(args) {
 	cloneTable = cloneTable.build()
 
 	clonotypeDefinitionFile := undefined
-    if args.clonotypeDefinition != undefined && len(args.clonotypeDefinition) > 0 {
-        clonotypeDefinitionTable := pframes.csvFileBuilder()
-        for i, columnRef in args.clonotypeDefinition {
-            clonotypeDefinitionTable.add(columns.getColumn(columnRef), {header: "clonotypeDefinition_" + i})
-        }
-        clonotypeDefinitionTable.setAxisHeader(abundanceSpec.axesSpec[1].name, "elementId")
-        clonotypeDefinitionTable.mem("16GiB")
-        clonotypeDefinitionTable.cpu(1)
-        clonotypeDefinitionFile = clonotypeDefinitionTable.build()
-    }
+	if args.clonotypeDefinition != undefined && len(args.clonotypeDefinition) > 0 {
+		clonotypeDefinitionTable := pframes.csvFileBuilder()
+		for i, columnRef in args.clonotypeDefinition {
+			clonotypeDefinitionTable.add(columns.getColumn(columnRef), {header: "clonotypeDefinition_" + i})
+		}
+		clonotypeDefinitionTable.setAxisHeader(abundanceSpec.axesSpec[1].name, "elementId")
+		clonotypeDefinitionTable.mem("16GiB")
+		clonotypeDefinitionTable.cpu(1)
+		clonotypeDefinitionFile = clonotypeDefinitionTable.build()
+	}
 
 	runDownsampling := exec.builder().
 		software(downsamplingSw).
@@ -143,18 +152,18 @@ wf.body(func(args) {
 		saveFile("result.csv").
 		run()
 	downsamplingFile := runDownsampling.getFile("result.csv")
-	
+
 	// Check if inputs are individual clonotypes or clusters
 	inputType := "Unknown"
 	if abundanceSpec.axesSpec[1].name == "pl7.app/clusterId" {
 		inputType = "Cluster"
 	} else if abundanceSpec.axesSpec[1].name == "pl7.app/vdj/clonotypeKey" ||
-				abundanceSpec.axesSpec[1].name == "pl7.app/vdj/scClonotypeKey" {
+	abundanceSpec.axesSpec[1].name == "pl7.app/vdj/scClonotypeKey" {
 		inputType = "Clonotype"
 	} else if abundanceSpec.axesSpec[1].name == "pl7.app/variantKey" {
 		inputType = "Peptide"
 	}
-	
+
 	//////////// Enrichment analysis ////////////
 	// Run enrichment script with boolean filtering flags for reliable cache differentiation
 	calculateEnrichment := exec.builder().
@@ -175,9 +184,9 @@ wf.body(func(args) {
 		arg("--filtered_too_much").arg("filtered_too_much.txt")
 
 	if clonotypeDefinitionFile != undefined {
-        calculateEnrichment = calculateEnrichment.addFile("clonotypeDefinition.csv", clonotypeDefinitionFile).
-		    arg("--clonotype-definition").arg("clonotypeDefinition.csv")
-    }
+		calculateEnrichment = calculateEnrichment.addFile("clonotypeDefinition.csv", clonotypeDefinitionFile).
+			arg("--clonotype-definition").arg("clonotypeDefinition.csv")
+	}
 
 	if antigenControlConfig.antigenEnabled || antigenControlConfig.controlEnabled {
 		calculateEnrichment = calculateEnrichment.
@@ -188,7 +197,7 @@ wf.body(func(args) {
 				arg("--sequenced_library_enabled").
 				arg("--sequenced_library_antigen").arg(string(antigenControlConfig.sequencedLibraryAntigen))
 		}
-		
+
 		if antigenControlConfig.controlEnabled {
 			calculateEnrichment = calculateEnrichment.
 				arg("--control_enabled").
@@ -203,7 +212,7 @@ wf.body(func(args) {
 	// Add filtering flags based on user selection
 	if FilteringConfig.baseFilter != "none" {
 		calculateEnrichment = calculateEnrichment.arg("--filter_clonotypes")
-		
+
 		if FilteringConfig.baseFilter == "single-sample" {
 			calculateEnrichment = calculateEnrichment.arg("--filter_single_sample")
 		} else if FilteringConfig.baseFilter == "shared" {
@@ -229,7 +238,7 @@ wf.body(func(args) {
 	// Apply in-round presence filters based on selection
 	if FilteringConfig.presentInRounds.enabled {
 		label = label + " - (" + FilteringConfig.presentInRounds.logic + ", " + string(FilteringConfig.presentInRounds.rounds) + ")"
-		
+
 		calculateEnrichment = calculateEnrichment.arg("--filter_clonotypes")
 		calculateEnrichment = calculateEnrichment.arg("--present_in_rounds").arg(string(FilteringConfig.presentInRounds.rounds))
 		calculateEnrichment = calculateEnrichment.arg("--present_in_rounds_logic").arg(FilteringConfig.presentInRounds.logic)
@@ -249,27 +258,27 @@ wf.body(func(args) {
 	// Convert script outputs to Pframes
 	enrichCsv := calculateEnrichment.getFile("enrichment_results.csv")
 
-    // Determine if we should add MaxNegControlEnrichment column
-    // It should be added only if there are multiple control conditions (either >1 conditions or >0 conditions + sequenced library)
+	// Determine if we should add MaxNegControlEnrichment column
+	// It should be added only if there are multiple control conditions (either >1 conditions or >0 conditions + sequenced library)
 	addMaxNegControlEnrichment := false
 	addPresentInNegControl := false
 	if antigenControlConfig.controlEnabled {
 		addMaxNegControlEnrichment = len(antigenControlConfig.controlConditionsOrder) > 1 ||
-			(len(antigenControlConfig.controlConditionsOrder) == 1  &&
-				antigenControlConfig.sequencedLibraryEnabled == true)
-			
+		(len(antigenControlConfig.controlConditionsOrder) == 1  &&
+			antigenControlConfig.sequencedLibraryEnabled == true)
+
 		addPresentInNegControl = antigenControlConfig.sequencedLibraryEnabled == false &&
-			(len(antigenControlConfig.controlConditionsOrder) == 1)
+		(len(antigenControlConfig.controlConditionsOrder) == 1)
 	}
 
-	enrichmentImportParams := pfEnrichmentConv.getColumns(abundanceSpec, conditionOrder, 
-		antigenControlConfig.controlEnabled, addPresentInNegControl, 
+	enrichmentImportParams := pfEnrichmentConv.getColumns(abundanceSpec, conditionOrder,
+		antigenControlConfig.controlEnabled, addPresentInNegControl,
 		addMaxNegControlEnrichment, antigenControlConfig.sequencedLibraryEnabled)
 	enrichmentPf := xsv.importFile(enrichCsv, "csv", enrichmentImportParams,
-									{ cpu: 1, mem: "32GiB" })
+		{ cpu: 1, mem: "32GiB" })
 	controlScatterPf := undefined
 	if antigenControlConfig.controlEnabled {
-		controlScatterImportParams := pfControlScatterConv.getColumns(abundanceSpec, 
+		controlScatterImportParams := pfControlScatterConv.getColumns(abundanceSpec,
 			conditionOrder, addPresentInNegControl, addMaxNegControlEnrichment)
 		controlScatterPf = xsv.importFile(enrichCsv, "csv", controlScatterImportParams,
 			{ cpu: 1, mem: "32GiB" })
@@ -278,41 +287,41 @@ wf.body(func(args) {
 	bubbleImportParams := pfBubbleConv.getColumns(abundanceSpec, addPresentInNegControl,
 		addMaxNegControlEnrichment)
 	bubblePf := xsv.importFile(calculateEnrichment.getFile("bubble_data.csv"), "csv", bubbleImportParams,
-							{ cpu: 1, mem: "32GiB" })
+		{ cpu: 1, mem: "32GiB" })
 
 	lineImportParams := pfStackedConv.getColumns(abundanceSpec, addPresentInNegControl, addMaxNegControlEnrichment)
 	linePf := xsv.importFile(calculateEnrichment.getFile("top_10.csv"), "csv", lineImportParams,
-							{ cpu: 1, mem: "32GiB" })
+		{ cpu: 1, mem: "32GiB" })
 
 	stackedImportParams := pfStackedConv.getColumns(abundanceSpec, addPresentInNegControl, addMaxNegControlEnrichment)
 	stackedPf := xsv.importFile(calculateEnrichment.getFile("top_enriched.csv"), "csv", stackedImportParams,
-								{ cpu: 1, mem: "32GiB" })
+		{ cpu: 1, mem: "32GiB" })
 
 	topEnrichedColCsv := calculateEnrichment.getFile("highest_enrichment_clonotype.csv")
 
 	// Export frequency
 	frequencyImportParams := pfFrequencyConv.getColumns(abundanceSpec, conditionOrder,
-														inputType, downsampling,
-														blockId, addPresentInNegControl,
-														addMaxNegControlEnrichment,
-														antigenControlConfig.sequencedLibraryEnabled)
+		inputType, downsampling,
+		blockId, addPresentInNegControl,
+		addMaxNegControlEnrichment,
+		antigenControlConfig.sequencedLibraryEnabled)
 	frequencyPf := xsv.importFile(enrichCsv, "csv", frequencyImportParams,
-								{ cpu: 1, mem: "32GiB" })
+		{ cpu: 1, mem: "32GiB" })
 
 	// Prepare pFrame to be exported
 	trace := pSpec.makeTrace(abundanceSpec,
-        {
-            type: "milaboratories.clonotype-enrichment",
-            importance: 30,
-            label: label
-        })
+		{
+			type: "milaboratories.clonotype-enrichment",
+			importance: 30,
+			label: label
+	})
 
-    exportsFreq := pframes.pFrameBuilder()
+	exportsFreq := pframes.pFrameBuilder()
 	for condition in conditionOrder {
 		colId := strings.substituteSpecialCharacters("frequency_" + condition)
 		exportsFreq.add(
-			"Frequency " + condition, 
-			trace.inject(frequencyPf[colId + ".spec"]), 
+			"Frequency " + condition,
+			trace.inject(frequencyPf[colId + ".spec"]),
 			frequencyPf[colId + ".data"]
 		)
 	}
@@ -388,25 +397,98 @@ wf.body(func(args) {
 	exports := buildExports.output("exports")
 	outStats := buildExports.output("outStats")
 
+	//////////// Per-clonotype Max Frequency (cluster input only) ////////////
+	// Compute each clonotype's max frequency across target rounds (same
+	// downsampling + frequency definition as the cluster-level frequencies) and
+	// export it on the clonotypeKey axis.
+	clonotypeFrequencyExport := undefined
+	if inputType == "Cluster" && args.clonotypeAbundanceRef != undefined {
+		clonoAbundanceSpec := columns.getSpec(args.clonotypeAbundanceRef)
+
+		clonoCloneTable := pframes.csvFileBuilder()
+		clonoCloneTable.add(columns.getColumn(args.clonotypeAbundanceRef), {header: "abundance"})
+		clonoCloneTable.add(columns.getColumn(args.conditionColumnRef), {header: "condition"})
+		if antigenControlConfig.antigenEnabled {
+			clonoCloneTable.add(columns.getColumn(antigenControlConfig.antigenColumnRef), {header: "antigen"})
+		}
+		clonoCloneTable.setAxisHeader(clonoAbundanceSpec.axesSpec[0].name, "sampleId")
+		clonoCloneTable.setAxisHeader(clonoAbundanceSpec.axesSpec[1].name, "elementId")
+		clonoCloneTable.mem("32GiB")
+		clonoCloneTable.cpu(1)
+		clonoCloneTable = clonoCloneTable.build()
+
+		// Same downsampling pipeline as the cluster-level frequencies.
+		clonoDownsampling := exec.builder().
+			software(downsamplingSw).
+			mem("32GiB").
+			cpu(8).
+			writeFile("downsampling.json", json.encode(downsampling)).
+			addFile("input.csv", clonoCloneTable).
+			saveFile("result.csv").
+			run()
+
+		clonoMaxFreq := exec.builder().
+			software(clonotypeMaxFreqSw).
+			mem("32GiB").
+			cpu(1).
+			addFile("inputFile.csv", clonoDownsampling.getFile("result.csv")).
+			arg("--input_data").arg("inputFile.csv").
+			arg("--conditions").arg(string(conditionOrder)).
+			arg("--pseudo_count").arg(string(args.pseudoCount)).
+			arg("--output").arg("clonotype_max_frequency.csv")
+		if antigenControlConfig.antigenEnabled {
+			clonoMaxFreq = clonoMaxFreq.arg("--current_target").arg(string(antigenControlConfig.targetAntigen))
+		}
+		clonoMaxFreq = clonoMaxFreq.
+			saveFile("clonotype_max_frequency.csv").
+			printErrStreamToStdout().
+			saveStdoutContent().
+			run()
+
+		clonoFreqImportParams := pfClonotypeFrequencyConv.getColumns(clonoAbundanceSpec, downsampling, conditionOrder, blockId)
+		clonoFreqPf := xsv.importFile(clonoMaxFreq.getFile("clonotype_max_frequency.csv"), "csv", clonoFreqImportParams,
+			{ cpu: 1, mem: "16GiB" })
+
+		clonoTrace := pSpec.makeTrace(clonoAbundanceSpec,
+			{
+				type: "milaboratories.clonotype-enrichment",
+				importance: 30,
+				label: label
+		})
+
+		clonoFreqExports := pframes.pFrameBuilder()
+		clonoFreqExports.add(
+			"Clonotype Max Frequency",
+			clonoTrace.inject(clonoFreqPf["maxfrequency.spec"]),
+			clonoFreqPf["maxfrequency.data"]
+		)
+		clonotypeFrequencyExport = clonoFreqExports.build()
+	}
+
 	// Define outputs
 	outputs := {
-			outStats: outStats,
-			enrichmentPf: pframes.exportFrame(enrichmentPf),
-			bubblePf: pframes.exportFrame(bubblePf),
-			stackedPf: pframes.exportFrame(stackedPf),
-			linePf: pframes.exportFrame(linePf),
-			filteredTooMuch: buildExports.output("filteredTooMuch")
-		}
+		outStats: outStats,
+		enrichmentPf: pframes.exportFrame(enrichmentPf),
+		bubblePf: pframes.exportFrame(bubblePf),
+		stackedPf: pframes.exportFrame(stackedPf),
+		linePf: pframes.exportFrame(linePf),
+		filteredTooMuch: buildExports.output("filteredTooMuch")
+	}
 	if antigenControlConfig.controlEnabled {
 		outputs.controlScatterPf = pframes.exportFrame(controlScatterPf)
 	}
 
+	exportsMap := {
+		pf: exports,
+		frequency: exportsFreq.build(),
+		additionalEnrichments: exportsAdditionalEnrichments.build()
+	}
+	if clonotypeFrequencyExport != undefined {
+		exportsMap.clonotypeFrequency = clonotypeFrequencyExport
+	}
+
 	return {
 		outputs: outputs,
-		exports: {
-			pf: exports,
-			frequency: exportsFreq.build(),
-			additionalEnrichments: exportsAdditionalEnrichments.build()
-		}
-	}	
+		exports: exportsMap
+	}
 })

--- a/workflow/src/pf-clonotype-frequency-conv.lib.tengo
+++ b/workflow/src/pf-clonotype-frequency-conv.lib.tengo
@@ -1,0 +1,48 @@
+ll := import("@platforma-sdk/workflow-tengo:ll")
+canonical := import("@platforma-sdk/workflow-tengo:canonical")
+
+// Conversion params for the per-clonotype Max Frequency column. Produced only
+// in cluster mode.
+//
+// clonoAbundanceSpec : spec of the discovered clonotype primary abundance
+//                      (axesSpec = [sampleId, clonotypeKey]).
+getColumns := func(clonoAbundanceSpec, downsampling, conditionOrder, blockId) {
+	return {
+		axes: [
+			{
+				column: "elementId",
+				spec: clonoAbundanceSpec.axesSpec[1]
+			}
+		],
+		columns: [{
+			column: "MaxFrequency",
+			id: "maxfrequency",
+			allowNA: true,
+			spec: {
+				name: "pl7.app/maxFrequency",
+				valueType: "Double",
+				domain: {
+					"pl7.app/downsampling": canonical.encode(downsampling),
+					"pl7.app/enrichment/conditionsOrder": canonical.encode(conditionOrder),
+					"pl7.app/blockId": blockId
+				},
+				annotations: {
+					"pl7.app/label": "Max Frequency",
+					"pl7.app/description": "Highest frequency the clonotype reaches across target selection rounds (library round and negative controls excluded).",
+					"pl7.app/table/visibility": "optional",
+					"pl7.app/table/orderPriority": "85",
+					"pl7.app/isScore": "true",
+					"pl7.app/score/rankingOrder": "decreasing",
+					"pl7.app/score/rankValues": "decreasing",
+					"pl7.app/format": ".2e"
+				}
+			}
+		}],
+		storageFormat: "Parquet",
+		partitionKeyLength: 0
+	}
+}
+
+export ll.toStrict({
+	getColumns: getColumns
+})

--- a/workflow/src/pf-clonotype-frequency-conv.lib.tengo
+++ b/workflow/src/pf-clonotype-frequency-conv.lib.tengo
@@ -1,12 +1,14 @@
 ll := import("@platforma-sdk/workflow-tengo:ll")
 canonical := import("@platforma-sdk/workflow-tengo:canonical")
+text := import("text")
 
-// Conversion params for the per-clonotype Max Frequency column. Produced only
+// Conversion params for the per-element Max Frequency column. Produced only
 // in cluster mode.
 //
-// clonoAbundanceSpec : spec of the discovered clonotype primary abundance
-//                      (axesSpec = [sampleId, clonotypeKey]).
-getColumns := func(clonoAbundanceSpec, downsampling, conditionOrder, blockId) {
+// clonoAbundanceSpec : spec of the discovered per-element primary abundance
+//                      (axesSpec = [sampleId, <element axis>]).
+// elementLabel       : "Clonotype" or "Peptide", used to label the column.
+getColumns := func(clonoAbundanceSpec, downsampling, conditionOrder, blockId, elementLabel) {
 	return {
 		axes: [
 			{
@@ -27,8 +29,8 @@ getColumns := func(clonoAbundanceSpec, downsampling, conditionOrder, blockId) {
 					"pl7.app/blockId": blockId
 				},
 				annotations: {
-					"pl7.app/label": "Max Frequency",
-					"pl7.app/description": "Highest frequency the clonotype reaches across target selection rounds (library round and negative controls excluded).",
+					"pl7.app/label": elementLabel + " Max Frequency",
+					"pl7.app/description": "Highest frequency the " + text.to_lower(elementLabel) + " reaches across target selection rounds (library round and negative controls excluded).",
 					"pl7.app/table/visibility": "optional",
 					"pl7.app/table/orderPriority": "85",
 					"pl7.app/isScore": "true",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a per-clonotype **Max Frequency** export for cluster-mode inputs. When the enrichment block receives cluster abundance, it auto-discovers the upstream clonotype primary abundance, runs it through the same downsampling pipeline, and computes each clonotype's maximum frequency across target selection rounds using a new Python script (`clonotype_max_frequency.py`). The result is exported on the clonotype-key axis as a `pl7.app/maxFrequency` score for Lead Selection ranking; no column is produced for clonotype/peptide inputs.

- **`BlockData` (model)**: gains `clonotypeAbundanceRef?: PlRef` — an optional persisted reference to the discovered upstream clonotype abundance; the new `discoveredClonotypeAbundance` output matches candidates by clonotype identity (cluster axis domain minus `pl7.app/clustering/` keys).
- **`MainPage.vue` (UI)**: a `watchEffect` bridges the auto-discovered ref into `data.clonotypeAbundanceRef`, with a guard to tolerate reactive recomputes, but this guard also suppresses clearing a stale ref when no match is found permanently.
- **`clonotype_max_frequency.py` (software)**: implements the frequency formula `(abundance + p) / (total + N*p)`, consistent with `enrichment.py`, with antigen-based target-track filtering and an empty-data early exit; missing a guard for an empty `condition_order`.
- **`pf-clonotype-frequency-conv.lib.tengo` + workflow**: wires the new downsampling → max-frequency pipeline in cluster mode and exports the result as a decreasing-rank score column.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The new cluster-mode Max Frequency pipeline is structurally sound, but the UI watcher can leave a stale `clonotypeAbundanceRef` from a previous cluster input when no match is found for the current one, causing the workflow to compute and export max frequency scores using the wrong clonotype abundance data.

The main enrichment path is unchanged. The new Python script and Tengo library are well-constructed and consistent with the existing enrichment patterns. However, the `watchEffect` guard in `MainPage.vue` cannot distinguish 'discovery still loading' from 'discovery permanently found no candidates,' so a stale reference from a prior cluster abundance can persist indefinitely and silently flow into the workflow output. This affects correctness of an exported score column without any runtime error signal.

ui/src/pages/MainPage.vue — the stale-ref guard needs a mechanism to distinguish transient from permanent undefined; software/src/clonotype_max_frequency.py — needs an early-exit when condition_order is empty.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model/src/index.ts | Adds optional `clonotypeAbundanceRef?: PlRef` to `BlockData` and a new `discoveredClonotypeAbundance` output that auto-discovers the upstream clonotype primary abundance by matching identity domains; logic is sound with correct optional chaining and `return undefined` on every early-exit path. |
| ui/src/pages/MainPage.vue | Adds a `watchEffect` that persists `discoveredClonotypeAbundance` into `data.clonotypeAbundanceRef`; the guard `if (isCluster && next === undefined) return` causes a stale ref when discovery permanently finds no match for a new cluster input. |
| software/src/clonotype_max_frequency.py | New Python script computing per-clonotype max frequency using the same pseudo-count formula as the main enrichment script; correctly handles antigen filtering, downsampled abundance, and empty data, but lacks a guard for an empty `condition_order` that would crash `pl.concat_list([])`. |
| workflow/src/main.tpl.tengo | Adds cluster-mode Max Frequency pipeline: bundles the clonotype abundance ref, runs a dedicated downsampling, then the new Python script, and exports results via `pf-clonotype-frequency-conv`; structure mirrors the existing enrichment pipeline correctly. |
| workflow/src/pf-clonotype-frequency-conv.lib.tengo | New Tengo library defining the `MaxFrequency` column spec (score, decreasing order, `pl7.app/maxFrequency`) keyed on the clonotype axis from the discovered abundance; domain includes downsampling, condition order, and blockId for cache differentiation. |
| software/package.json | Registers the new `clonotype-max-frequency` software artifact using the existing Python 3.12 environment and shared `requirements.txt`, consistent with the existing `downsampling` entry. |
| .changeset/max-frequency-export.md | Changeset file bumping all packages to minor; description accurately captures the feature scope. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as MainPage.vue
    participant Model as model/index.ts
    participant Pool as ResultPool
    participant WF as main.tpl.tengo
    participant DS as downsampling.py
    participant MF as clonotype_max_frequency.py
    participant Conv as pf-clonotype-frequency-conv

    UI->>Model: watchEffect reads discoveredClonotypeAbundance
    Model->>Pool: getOptions(isAbundance, isPrimary, !normalized)
    Pool-->>Model: candidate PlRefs
    Model-->>UI: clonotypeAbundanceRef (or undefined)
    UI->>Model: "data.clonotypeAbundanceRef = ref"

    Note over WF: Workflow runs (Cluster mode only)
    WF->>WF: build clonoCloneTable CSV (clonotype abundance + condition [+ antigen])
    WF->>DS: run downsampling on clonoCloneTable
    DS-->>WF: result.csv (downsampled)
    WF->>MF: --input_data result.csv / --conditions conditionOrder / --pseudo_count / [--current_target antigen]
    MF-->>WF: clonotype_max_frequency.csv
    WF->>Conv: getColumns(clonoAbundanceSpec, ...)
    Conv-->>WF: import params
    WF->>WF: xsv.importFile → clonoFreqPf
    WF-->>WF: export as clonotypeFrequency (pl7.app/maxFrequency score)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as MainPage.vue
    participant Model as model/index.ts
    participant Pool as ResultPool
    participant WF as main.tpl.tengo
    participant DS as downsampling.py
    participant MF as clonotype_max_frequency.py
    participant Conv as pf-clonotype-frequency-conv

    UI->>Model: watchEffect reads discoveredClonotypeAbundance
    Model->>Pool: getOptions(isAbundance, isPrimary, !normalized)
    Pool-->>Model: candidate PlRefs
    Model-->>UI: clonotypeAbundanceRef (or undefined)
    UI->>Model: "data.clonotypeAbundanceRef = ref"

    Note over WF: Workflow runs (Cluster mode only)
    WF->>WF: build clonoCloneTable CSV (clonotype abundance + condition [+ antigen])
    WF->>DS: run downsampling on clonoCloneTable
    DS-->>WF: result.csv (downsampled)
    WF->>MF: --input_data result.csv / --conditions conditionOrder / --pseudo_count / [--current_target antigen]
    MF-->>WF: clonotype_max_frequency.csv
    WF->>Conv: getColumns(clonoAbundanceSpec, ...)
    Conv-->>WF: import params
    WF->>WF: xsv.importFile → clonoFreqPf
    WF-->>WF: export as clonotypeFrequency (pl7.app/maxFrequency score)
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aui%2Fsrc%2Fpages%2FMainPage.vue%3A862-872%0A**Stale%20%60clonotypeAbundanceRef%60%20when%20discovery%20permanently%20finds%20no%20match**%0A%0AThe%20guard%20%60if%20%28isCluster%20%26%26%20next%20%3D%3D%3D%20undefined%29%20return%60%20is%20intended%20to%20tolerate%20transient%20recomputations%2C%20but%20it%20cannot%20distinguish%20between%20%22discovery%20is%20still%20loading%22%20and%20%22discovery%20permanently%20found%20no%20candidates.%22%20When%20a%20user%20switches%20to%20a%20cluster%20abundance%20that%20has%20no%20matching%20upstream%20clonotype%20abundance%20in%20the%20result%20pool%2C%20%60discoveredClonotypeAbundance%60%20returns%20%60undefined%60%20forever.%20The%20guard%20fires%20on%20every%20reactive%20re-run%2C%20so%20the%20previous%20%28now%20wrong%29%20%60clonotypeAbundanceRef%60%20is%20never%20cleared.%20The%20workflow%20will%20then%20use%20a%20clonotype%20abundance%20from%20a%20completely%20different%20cluster%20input%2C%20silently%20producing%20incorrect%20Max%20Frequency%20values%20without%20any%20error%20signal.%0A%0A%23%23%23%20Issue%202%20of%202%0Asoftware%2Fsrc%2Fclonotype_max_frequency.py%3A100-113%0A%60freq_cols%60%20will%20be%20empty%20when%20%60condition_order%60%20is%20empty%20%28e.g.%2C%20no%20conditions%20configured%20yet%29.%20%60pl.concat_list%28%5B%5D%29%60%20raises%20a%20Polars%20error%20in%20that%20case.%20Guard%20early%20so%20the%20script%20writes%20the%20empty%20CSV%20instead%20of%20crashing.%0A%0A%60%60%60suggestion%0A%20%20%20%20%23%20Per-condition%20frequency%2C%20then%20max%20across%20the%20target%20rounds%20only.%0A%20%20%20%20freq_cols%20%3D%20%5B%5D%0A%20%20%20%20for%20c%20in%20condition_order%3A%0A%20%20%20%20%20%20%20%20if%20c%20not%20in%20pivot.columns%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20pivot%20%3D%20pivot.with_columns%28pl.lit%280%29.alias%28c%29%29%0A%20%20%20%20%20%20%20%20total%20%3D%20totals.get%28c%2C%201%29%0A%20%20%20%20%20%20%20%20denom%20%3D%20total%20%2B%20%28n_clonotypes%20*%20pseudo%29%0A%20%20%20%20%20%20%20%20if%20denom%20%3C%3D%200%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20denom%20%3D%201%0A%20%20%20%20%20%20%20%20freq_name%20%3D%20f%22freq_%7Bc%7D%22%0A%20%20%20%20%20%20%20%20pivot%20%3D%20pivot.with_columns%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%28%28pl.col%28c%29%20%2B%20pseudo%29%20%2F%20denom%29.alias%28freq_name%29%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20freq_cols.append%28freq_name%29%0A%0A%20%20%20%20if%20not%20freq_cols%3A%0A%20%20%20%20%20%20%20%20empty.write_csv%28args.output%29%0A%20%20%20%20%20%20%20%20return%0A%60%60%60%0A%0A&repo=platforma-open%2Fclonotype-enrichment&pr=103&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
ui/src/pages/MainPage.vue:862-872
**Stale `clonotypeAbundanceRef` when discovery permanently finds no match**

The guard `if (isCluster && next === undefined) return` is intended to tolerate transient recomputations, but it cannot distinguish between "discovery is still loading" and "discovery permanently found no candidates." When a user switches to a cluster abundance that has no matching upstream clonotype abundance in the result pool, `discoveredClonotypeAbundance` returns `undefined` forever. The guard fires on every reactive re-run, so the previous (now wrong) `clonotypeAbundanceRef` is never cleared. The workflow will then use a clonotype abundance from a completely different cluster input, silently producing incorrect Max Frequency values without any error signal.

### Issue 2 of 2
software/src/clonotype_max_frequency.py:100-113
`freq_cols` will be empty when `condition_order` is empty (e.g., no conditions configured yet). `pl.concat_list([])` raises a Polars error in that case. Guard early so the script writes the empty CSV instead of crashing.

```suggestion
    # Per-condition frequency, then max across the target rounds only.
    freq_cols = []
    for c in condition_order:
        if c not in pivot.columns:
            pivot = pivot.with_columns(pl.lit(0).alias(c))
        total = totals.get(c, 1)
        denom = total + (n_clonotypes * pseudo)
        if denom <= 0:
            denom = 1
        freq_name = f"freq_{c}"
        pivot = pivot.with_columns(
            ((pl.col(c) + pseudo) / denom).alias(freq_name)
        )
        freq_cols.append(freq_name)

    if not freq_cols:
        empty.write_csv(args.output)
        return
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Changeset"](https://github.com/platforma-open/clonotype-enrichment/commit/bb094bddfa65dde09ea0697526c7c18d0335ac6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39555887)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->