### PR TITLE
chore: refresh SDK dependencies and block structure

### DIFF
--- a/.changeset/upgrade-sdk.md
+++ b/.changeset/upgrade-sdk.md
@@ -1,0 +1,8 @@
+---
+"@platforma-open/milaboratories.clonotype-enrichment": patch
+"@platforma-open/milaboratories.clonotype-enrichment.model": patch
+"@platforma-open/milaboratories.clonotype-enrichment.ui": patch
+"@platforma-open/milaboratories.clonotype-enrichment.workflow": patch
+---
+
+SDK Update

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -10,10 +10,12 @@ import type {
 import {
   Annotation,
   BlockModelV3,
+  ColumnLazy,
+  ColumnsCollection,
   DataModelBuilder,
   createPFrameForGraphs,
   createPlDataTableStateV2,
-  createPlDataTableV2,
+  createPlDataTableV3,
   getUniquePartitionKeys,
   readAnnotationJson,
 } from "@platforma-sdk/model";
@@ -446,7 +448,7 @@ export const platforma = BlockModelV3.create(dataModel)
   .outputWithStatus("pt", (ctx) => {
     const pCols = ctx.outputs?.resolve("enrichmentPf")?.getPColumns();
 
-    if (pCols === undefined) {
+    if (!pCols?.length) {
       return undefined;
     }
 
@@ -454,68 +456,62 @@ export const platforma = BlockModelV3.create(dataModel)
     const anchor = ctx.data.abundanceRef;
     const enrichmentAxisName = pCols[0]?.spec.axesSpec[0]?.name;
     const allSeqCols = anchor
-      ? (
-          ctx.resultPool.getAnchoredPColumns(
-            { main: anchor },
-            [
-              { axes: [{ anchor: "main", idx: 1 }], name: "pl7.app/vdj/sequence" },
-              { axes: [{ anchor: "main", idx: 1 }], name: "pl7.app/sequence" },
+      ? ColumnsCollection(["result_pool"], { ctx: ctx.ctx })
+          .discover({
+            anchors: { main: anchor },
+            include: [
+              { name: [{ type: "exact", value: "pl7.app/vdj/sequence" }] },
+              { name: [{ type: "exact", value: "pl7.app/sequence" }] },
             ],
-            { dontWaitAllData: true },
-          ) ?? []
-        ).filter(
-          (col) =>
+            mode: "enrichment",
+          })
+          .getColumns()
+          .filter(
             // Skip if axis doesn't match enrichment (e.g. stale results after switching input)
-            col.spec.axesSpec[0]?.name === enrichmentAxisName,
-        )
+            (col) => col.getSpec().axesSpec[0]?.name === enrichmentAxisName,
+          )
       : [];
 
     // Assembling feature (or centroid) amino acid sequences — visible by default
     const mainSeqCols = allSeqCols
       .filter((col) => {
-        const alphabet = col.spec.domain?.["pl7.app/alphabet"];
+        const spec = col.getSpec();
+        const alphabet = spec.domain?.["pl7.app/alphabet"];
         // !== false (not === true) to also match cluster centroid sequences,
         // where clonotype-clustering deletes the isAssemblingFeature annotation
         return (
           alphabet === "aminoacid" &&
-          readAnnotationJson(col.spec, Annotation.VDJ.IsAssemblingFeature) !== false
+          readAnnotationJson(spec, Annotation.VDJ.IsAssemblingFeature) !== false
         );
       })
-      .map((col) => ({
-        ...col,
-        spec: {
-          ...col.spec,
+      .map((col) =>
+        col.withSpecs({
           annotations: {
-            ...col.spec.annotations,
             "pl7.app/table/visibility": "default",
             "pl7.app/table/orderPriority": "1",
           },
-        },
-      }));
+        }),
+      );
 
     // Other region sequences (CDR1, CDR2, FR1, etc.) — not shown by default, available in column picker
     const otherRegionCols = allSeqCols
-      .filter((col) => readAnnotationJson(col.spec, Annotation.VDJ.IsAssemblingFeature) === false)
-      .map((col) => ({
-        ...col,
-        spec: {
-          ...col.spec,
-          annotations: { ...col.spec.annotations, "pl7.app/table/visibility": "optional" },
-        },
-      }));
+      .filter(
+        (col) => readAnnotationJson(col.getSpec(), Annotation.VDJ.IsAssemblingFeature) === false,
+      )
+      .map((col) => col.withSpecs({ annotations: { "pl7.app/table/visibility": "optional" } }));
 
-    return createPlDataTableV2(
-      ctx,
-      [...pCols, ...mainSeqCols, ...otherRegionCols],
-      ctx.data.tableState,
-      {
-        // Sequence columns are non-core so they are left-joined: they won't
-        // bring back clonotypes that were filtered out during enrichment
-        coreColumnPredicate: ({ spec }) =>
-          spec.name !== "pl7.app/vdj/sequence" && spec.name !== "pl7.app/sequence",
-        coreJoinType: "inner",
-      },
-    );
+    return createPlDataTableV3(ctx, {
+      // Single primary: V3 anchors label discovery per primary column, and several
+      // same-axis enrichment columns collide. They share one PFrame, so joining
+      // the rest as secondary is equivalent to the old inner join among core columns.
+      primaryColumns: [ColumnLazy.fromColumn(pCols[0])],
+      columns: [
+        ...pCols.slice(1).map((c) => ColumnLazy.fromColumn(c)),
+        ...mainSeqCols,
+        ...otherRegionCols,
+      ],
+      tableState: ctx.data.tableState,
+    });
   })
 
   // Returns a map of results for plot

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: 1.6.1
       version: 1.6.1
     '@milaboratories/helpers':
-      specifier: 1.14.3
-      version: 1.14.3
+      specifier: 1.14.4
+      version: 1.14.4
     '@milaboratories/ts-builder':
       specifier: 1.6.0
       version: 1.6.0
@@ -28,23 +28,23 @@ catalogs:
       specifier: 1.6.6
       version: 1.6.6
     '@platforma-sdk/block-tools':
-      specifier: 2.12.4
-      version: 2.12.4
+      specifier: 2.12.7
+      version: 2.12.7
     '@platforma-sdk/model':
-      specifier: 1.79.27
-      version: 1.79.27
+      specifier: 1.80.2
+      version: 1.80.2
     '@platforma-sdk/tengo-builder':
-      specifier: 4.0.16
-      version: 4.0.16
+      specifier: 4.0.18
+      version: 4.0.18
     '@platforma-sdk/test':
-      specifier: 1.79.34
-      version: 1.79.34
+      specifier: 1.80.5
+      version: 1.80.5
     '@platforma-sdk/ui-vue':
-      specifier: 1.79.34
-      version: 1.79.34
+      specifier: 1.80.4
+      version: 1.80.4
     '@platforma-sdk/workflow-tengo':
-      specifier: 6.7.1
-      version: 6.7.1
+      specifier: 6.7.2
+      version: 6.7.2
     '@vueuse/core':
       specifier: ^13.3.0
       version: 13.9.0
@@ -89,7 +89,7 @@ importers:
         version: 1.6.0(@types/node@24.5.2)(rollup@4.52.0)(sass-embedded@1.89.0)(vue@3.5.26(typescript@5.6.3))(yaml@2.8.2)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.4(@types/node@24.5.2)
+        version: 2.12.7(@types/node@24.5.2)
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -119,10 +119,10 @@ importers:
         version: link:../workflow
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.4(@types/node@24.5.2)
+        version: 2.12.7(@types/node@24.5.2)
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.27
+        version: 1.80.2
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -134,13 +134,13 @@ importers:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.6.1(@milaboratories/pl-model-common@1.46.4)(@platforma-sdk/model@1.79.27)(@platforma-sdk/ui-vue@1.79.34(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
+        version: 1.6.1(@milaboratories/pl-model-common@1.47.1)(@platforma-sdk/model@1.80.2)(@platforma-sdk/ui-vue@1.80.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
       '@milaboratories/helpers':
         specifier: 'catalog:'
-        version: 1.14.3
+        version: 1.14.4
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.27
+        version: 1.80.2
       '@types/node':
         specifier: '*'
         version: 24.5.2
@@ -156,7 +156,7 @@ importers:
         version: 1.3.0
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.4(@types/node@24.5.2)
+        version: 2.12.7(@types/node@24.5.2)
       eslint:
         specifier: 'catalog:'
         version: 9.39.2
@@ -168,7 +168,7 @@ importers:
         version: 1.4.12
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.4(@types/node@24.5.2)
+        version: 2.12.7(@types/node@24.5.2)
 
   test:
     dependencies:
@@ -187,7 +187,7 @@ importers:
         version: 1.3.0
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.79.34(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@6.4.1(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.0)(yaml@2.8.2))
+        version: 1.80.5(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@6.4.1(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.0)(yaml@2.8.2))
       vitest:
         specifier: 'catalog:'
         version: 4.0.16(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.0)(yaml@2.8.2)
@@ -196,16 +196,16 @@ importers:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.6.1(@milaboratories/pl-model-common@1.46.4)(@platforma-sdk/model@1.79.27)(@platforma-sdk/ui-vue@1.79.34(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
+        version: 1.6.1(@milaboratories/pl-model-common@1.47.1)(@platforma-sdk/model@1.80.2)(@platforma-sdk/ui-vue@1.80.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
       '@platforma-open/milaboratories.clonotype-enrichment.model':
         specifier: workspace:*
         version: link:../model
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.27
+        version: 1.80.2
       '@platforma-sdk/ui-vue':
         specifier: 'catalog:'
-        version: 1.79.34(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
+        version: 1.80.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
       '@types/node':
         specifier: '*'
         version: 24.5.2
@@ -239,17 +239,17 @@ importers:
         version: link:../software
       '@platforma-sdk/workflow-tengo':
         specifier: 'catalog:'
-        version: 6.7.1
+        version: 6.7.2
     devDependencies:
       '@platforma-open/milaboratories.software-ptransform':
         specifier: 'catalog:'
         version: 1.6.6
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
-        version: 4.0.16
+        version: 4.0.18
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.79.34(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.0)(yaml@2.8.2))
+        version: 1.80.5(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.0)(yaml@2.8.2))
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -1140,8 +1140,11 @@ packages:
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
 
-  '@milaboratories/computable@2.9.6':
-    resolution: {integrity: sha512-Au+84jboSJMM2k39mWUFCtPl2wkislD1fLbb45du1PcAg1GSER1ThSLoBpZUQC2oiTt804WmbzhZ2yaoVZiVLQ==}
+  '@milaboratories/columns-collection-driver@0.2.1':
+    resolution: {integrity: sha512-CYdDAhmB01jYq0IXJmbMbA/yTfqSkzwRs0ZJxoSvnzvlu1doc63VIXSvhHOw9b70usR5EFVprR2PvPMTRnjeQQ==}
+
+  '@milaboratories/computable@2.9.7':
+    resolution: {integrity: sha512-uCMretdt4okbKWkU0aZ0+NHH3hN0wzi2ZIkAvwqha0ZTxUqKilDOlZNAL6QLbmT/7vQs9geAj4amlwSgzkMoww==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/graph-maker@1.6.1':
@@ -1158,11 +1161,15 @@ packages:
     resolution: {integrity: sha512-nZv+n+orVzA/GimDTNj6Yjb52+Wu5f/Kf2z6UCGXni6KTquLBfQhi3AFB1mLE7hkUYPvKU6LxuRY02CQMQiTVA==}
     engines: {node: '>=22'}
 
+  '@milaboratories/helpers@1.14.4':
+    resolution: {integrity: sha512-0mS5GQAQYUab0qj1C6+IXafNJhL1ahnhPBmIkLq9VqJU8p9jNZ7KC5ln4/pl0tK47brdPljCLEiLg8IdSa6wFw==}
+    engines: {node: '>=22'}
+
   '@milaboratories/miplots4@1.4.0':
     resolution: {integrity: sha512-Fsopmq+q3nkYyCNRJbmLpyDBU7rXJqMoAaNA3hnfeCa3RquGA6uOOl/ONKmqCJ35j+s+L7ch7a3Vt4IG2qeLtg==}
 
-  '@milaboratories/pf-driver@1.7.16':
-    resolution: {integrity: sha512-yujIUylT11CwM4alKVETxTnXQpcKHH1x5hZIAKTni/Q98JHs+teewNhUwpaWACwjuEhmF3EYSTgTXeUoeI9hAg==}
+  '@milaboratories/pf-driver@1.8.2':
+    resolution: {integrity: sha512-K5jKzqFfsOJL051U1VAg2Iy9iE01Hwm+FtRb2/PcB0DV3VItIozXRF/mvcXKDHbSCLcPcRGqZjtEF3kMczd+sA==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pf-plots@1.5.0':
@@ -1171,79 +1178,79 @@ packages:
       '@milaboratories/pl-model-common': 1.46.4
       '@platforma-sdk/model': 1.79.27
 
-  '@milaboratories/pf-spec-driver@1.4.18':
-    resolution: {integrity: sha512-lXaoSyGCWUlrYZaoyRIWWT0Hpx9DWODXI7VdraNjYnCofJpYKMdAZW3sfCE9kdVup8ic29vywNPLeTjrVQ24sg==}
+  '@milaboratories/pf-spec-driver@1.4.21':
+    resolution: {integrity: sha512-JuYVQKs4aia8DA8MVqdImu+Ho+uTwwOqIaJ3VVPMpCMo3QAH9jZP+wGlkklSwow4d+27Y8L2RJN/1dcPr56GZw==}
 
-  '@milaboratories/pframes-rs-node@1.1.52':
-    resolution: {integrity: sha512-Uu4KsQx0GiKvFASI+Cm0nMCMieUVo35mpz4j8mYUYImr7S+bVDDcHweCWrkLkSeImnOQnYHVo9RycViG6QwUQw==}
+  '@milaboratories/pframes-rs-node@1.1.55':
+    resolution: {integrity: sha512-TbudDPMixADLyVr5UsiXhf+zq7YCJA3osFrzDn7Lr5aeyorCjiXDkVOGKpID7GkkssuVsNpPXtoGdA71Y2tLjQ==}
 
-  '@milaboratories/pframes-rs-serv@1.1.52':
-    resolution: {integrity: sha512-yVfcyLztgj5UAffj30se5G4MwxkIOFVWPHY1tZZ8zLhQQzx95R/e1toAqq3FLV7y6kpJovwmLusbefgKw9Ejcg==}
+  '@milaboratories/pframes-rs-serv@1.1.55':
+    resolution: {integrity: sha512-cGByUULBA/JiwyFEBZrVNOEbnbrMPWWHCWLprRKlVWlmDMaRmsVft/tFpnle46BhDZWpoWbaKEZ8NGOtGqDCXw==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasip2@1.1.52':
-    resolution: {integrity: sha512-0rb0We6Q/aqrHJ062dayvLb4RExODZdqfsVWdzeHq23alY5TjJRMWsO9aKQpPnOuUKjAimdjlp+Ldq9TVhbEtg==}
+  '@milaboratories/pframes-rs-wasip2@1.1.55':
+    resolution: {integrity: sha512-mwKTmcDiuN6Id2h+oxKX2W5igFhMxDvRZs4clsxhPTYZASSROrvsSsaoXS81meqfC0phx+BUaRpdrkVQIKSdxQ==}
 
-  '@milaboratories/pframes-rs-wasm@1.1.52':
-    resolution: {integrity: sha512-Wn8/LJxcsvWSSpdymdebWrBnmgu9wAbzvOiHCtXz7Aqt1M2T8Xp9a7CprzCYx+EvhSuAuoxbq6naxkPsQrbkvg==}
+  '@milaboratories/pframes-rs-wasm@1.1.55':
+    resolution: {integrity: sha512-kVOL+eAasfeiui5lQ5G92nsSiTNSsOnl1m+4my0tmbR7VTCa15dn1kd5RcXS3/8YO5oEcnGlCUhnu5kKMtweEw==}
     peerDependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
       '@milaboratories/pl-model-common': 1.46.2
       '@milaboratories/pl-model-middle-layer': 1.30.7
 
-  '@milaboratories/pl-client@3.14.0':
-    resolution: {integrity: sha512-WpKN8u71VAIJ6uYAdZqNe3/Ob73noxw7GW8JFZoIMqGVLwvTAbVyffjKuuH4V9S/hA+OXpv7/Dfxqpph5eAVYg==}
+  '@milaboratories/pl-client@3.14.2':
+    resolution: {integrity: sha512-+0ih1njQn4wvLjGmFKboKFRlWYLrzg7QdRK2aNo8ivTKY16TrsMRCk0GQEt0aPKELnv7QSrsNSjg7e7GSdGMDQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-config@1.8.3':
-    resolution: {integrity: sha512-JPIWG/9q7SL9QSYUhHwF9MCfGbpJyo2KxaO9IE2gEvy+oiGw1oBJvNdthC9V/uW2jHp/Qov9+x7LveHzN+bfeA==}
+  '@milaboratories/pl-config@1.8.4':
+    resolution: {integrity: sha512-eBZCIVhl9jRigyJUPURCxH2f2OrU5aToihSrwmTkCOu2rjr1spe4YGMIh9CxPr8Z1GkfQbez3crJGME1+RZrrg==}
 
-  '@milaboratories/pl-deployments@3.0.10':
-    resolution: {integrity: sha512-AEFI5gRH1quEUZPqV4wkYabVevpTRGMJXPILsYGh/In9eSw56aHIl8pHoZP5h8v3J5v//KNU7aP8sYANh8S7rA==}
+  '@milaboratories/pl-deployments@3.0.12':
+    resolution: {integrity: sha512-Oo7MGAwMyC8F5zCZWgs3Q/sET584Ussux8YP6TB+UBfWcNwZVZWbiO/QaRewfjnMfKSJ4Uden7RoQ4hHWvWChA==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-drivers@1.16.8':
-    resolution: {integrity: sha512-w8K++36KQZkDIkVz5Wk/TXBT8h+KG99eMpWjo3Esq9tK+8v9ZiswTBNuG99Wtg3vdBAaJfqf4iqeblSwZk8QcQ==}
+  '@milaboratories/pl-drivers@1.16.10':
+    resolution: {integrity: sha512-5lrewLkmN9Z6dWkRw2kYbsjquHNSHBni8seTI3BsP9xijuv4NzEkvDcJLJsQsuZcuaFtyw77fHAKvNmlYZiJeA==}
     engines: {node: '>=22'}
 
   '@milaboratories/pl-error-like@1.12.10':
     resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
 
-  '@milaboratories/pl-errors@1.4.29':
-    resolution: {integrity: sha512-j1iyOgoUlyk4/HvfhRfzvYRxkN4p01XjmFtdlTu8YdRQRp7goNZXtzTOMFAvltocb+ZeRjEOxIW5+3dsbXsFmA==}
+  '@milaboratories/pl-errors@1.4.31':
+    resolution: {integrity: sha512-XK4npZNtHksD+IHuzsaf4SXtceqRpwCH/PxZy7zijFqNuW5cdl7be8Parr8T+wQzYaDgHLVSKrYilzC56RNx/Q==}
 
-  '@milaboratories/pl-healthcheck@1.0.2':
-    resolution: {integrity: sha512-IBXQOSgJj7T/dw26AXBsR1ZaOpoqxZtSFZVPE2TonT0VaLKH4XqMFa3C+fKV1aECqbI45dBRQl/X70CUdGPWgQ==}
+  '@milaboratories/pl-healthcheck@1.0.3':
+    resolution: {integrity: sha512-krt75tuov2T0TKAsybbSzwHt45JjAQJbnqya0FiRApme913k6DvoowEX2NYLzRChbn+QVbs4ODxJI8lcgFexVg==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-middle-layer@1.65.9':
-    resolution: {integrity: sha512-ICbmXZRskk2RSRqthxtBzzkS1Jyc8ccUAHoxV3BplbCtzOS9M+QcebPFg+pCRE6cEDJG+DlMCTOUNL4k6MX5HQ==}
+  '@milaboratories/pl-middle-layer@1.66.4':
+    resolution: {integrity: sha512-rFyxoWpFNjA5FPU6A5Usf0FyDx+XzFSsDqsPRf3NVuxrk6No6cNGZVUerdpXZJ6qCEsJwdgMBRECyBI5MV5bRw==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-model-backend@1.4.14':
-    resolution: {integrity: sha512-8hn28/D59y3914PJXaOX2B5HBOYplaBhyvKPhsOjlAUhNATa9QBMMqVmYW5ZUJ8m8zZJJvOUVS8FShBMQQbjFA==}
+  '@milaboratories/pl-model-backend@1.4.16':
+    resolution: {integrity: sha512-MrJwM3aOzrqr3+GVpS/1Zh/SOH/2tBtoyk/+eE6C7LRjofoip8GIF4be8AgPAM3C+6wTSGrQ5x3CM6A8Ql2HVA==}
 
   '@milaboratories/pl-model-common@1.46.2':
     resolution: {integrity: sha512-VEeauisApYScvCS8lnK3zpFJ520xuTAodKJmjR8ulHcMrWMyWMfHEdGb7j5OMD0mM/OwTgmQrrJ5eB7Xd+xoOQ==}
 
-  '@milaboratories/pl-model-common@1.46.4':
-    resolution: {integrity: sha512-QArgLyQkf8kHSQquxStyk5Xfnau8S4M2vKEbUVQRRoZCzLU1lcDVXRwGgAzRH5NizeqYNrB/wt0/tShajH+6eA==}
+  '@milaboratories/pl-model-common@1.47.1':
+    resolution: {integrity: sha512-5F9I8JvUPRJ2HEzz5MmTio6JFYnhYoMVHfToh2NyXyOyQgAF6jhOzZBOsrEig9NfCPZBRB7v6UjmIK43dG4o/g==}
 
-  '@milaboratories/pl-model-middle-layer@1.30.11':
-    resolution: {integrity: sha512-yFThwVqOTb2gJw/tp4PkZcsKI7yRRJCX3QuA6fIc2+tNxCqyEQmdpLmaIY/nhaziIp9ByBT9MrzWNIQd1T9aww==}
+  '@milaboratories/pl-model-middle-layer@1.30.13':
+    resolution: {integrity: sha512-owQVozyub/6aKgk+yce+9sDK+t0HrpLbnlKJqQjYJahuhoju8j6VMY17AWgvADSDCiI3gnp/Tm/I4Ur6ySs1Cg==}
 
   '@milaboratories/pl-model-middle-layer@1.30.7':
     resolution: {integrity: sha512-rs9x3Ron4ujR/UOdEgB8WUB1SvZ8ZAScT1Av/e4or+iiQ/CzhmK9nqtYamHVwKV+JgwIFbXQwxGvIHDVz955dQ==}
 
-  '@milaboratories/pl-tree@1.12.19':
-    resolution: {integrity: sha512-Mod4gxBFgpBrLYqB6qIhUolQRrU+PvPgpj2auP3G6KF6GExy2GkZkJ3XX4fKd3sXLWsBim3ISidmA7YWp3Zezw==}
+  '@milaboratories/pl-tree@1.13.1':
+    resolution: {integrity: sha512-NtVVUSF9eJA5v5iUEfGgKl0JbG/EIvy+YCsxzCZ1dXG1S3gCNwt01Nj5PkWW7FkDG1IT0ZfwyeO0mVVz2kIv1Q==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/ptabler-expression-js@1.2.33':
-    resolution: {integrity: sha512-ThB7tc0nPACE7b8cSoA0+zRVZfZHOCAcFioFDi207G5prgrIc/z2zbInjD0PRnWFHO7xOsfbWCkNRDqCmut6zQ==}
+  '@milaboratories/ptabler-expression-js@1.2.35':
+    resolution: {integrity: sha512-nTVNYgNHuUswPnAe8GFAitbewNVMHaxhAncQ3yMYfGzsGgZupQyGV6K1DHVkzMAwNwVFVLwIbiPMY58en03XWQ==}
 
   '@milaboratories/resolve-helper@1.1.3':
     resolution: {integrity: sha512-38/dW/XRZQREOxAOOKtO0lzEWPCP/DH0qhB3q1kYcGoN++5V92/zbVwbYrMDeDcjTyo+D62iIep+sKXeWHa7Uw==}
@@ -1263,12 +1270,12 @@ packages:
   '@milaboratories/ts-configs@1.3.0':
     resolution: {integrity: sha512-6rZaMOJotG+v6eXoupHgPqxArpNBNl0f7sd5K+kUo1PUhPTe632eLJtEeBbFtwDGNYqL9QUacd4pT5t6oDOf0A==}
 
-  '@milaboratories/ts-helpers@1.8.4':
-    resolution: {integrity: sha512-YdOyANkJjFiEZgS3bfbludDo9PWOQZQ8AhGw/rpO5/7bgQ9RIVOOTAtP5/UppANoeUiYhCgJt/xvIZgnQ/PZ0w==}
+  '@milaboratories/ts-helpers@1.8.5':
+    resolution: {integrity: sha512-vZDcIBta7I935VjKk6qGdhpjz2pWXe5CbWv1UUmPrcG8wsunDpWuet8/Gi75N97CpcLDc2LLHd/url9K8ZNpAg==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/uikit@2.15.14':
-    resolution: {integrity: sha512-alefttXyF4j1h1riJMJypgalcVSQ1KFHD2P4r6kOe2uPrrI7CjpBrrn6GCqUmLmvRe/mz8eNFvoyiZBo4pe5BQ==}
+  '@milaboratories/uikit@2.15.16':
+    resolution: {integrity: sha512-HOl1YsPKHpj3izKAs0hEvVtFE8ZbrOnD5KsAqSHxvipQyfAdOLbfB7ak6XPdPKbgsvH5opfMws7usryR6Nlulw==}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -1586,11 +1593,11 @@ packages:
   '@platforma-open/milaboratories.runenv-python-3@1.4.12':
     resolution: {integrity: sha512-noouDr20aiASOdFHVhoZ0Y8JXrSw96pdZXmGJBXnwmRRryOf7kKdKIvX1n0rteWUmbJVGU4zVxFQWDC4VRuHeQ==}
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.15.17':
-    resolution: {integrity: sha512-Qf4QpFY8bWVtEeQphWGZ67dUaXYVWSFm/AL1ErzdOYhilnDSon2Cya6K2Fkj0TxEGBLMBxOudF/kmTw728/Pag==}
+  '@platforma-open/milaboratories.software-ptabler.schema@1.15.19':
+    resolution: {integrity: sha512-h/FBLELZT6PJZnWtwvcy8bQrpZ2A6xWSVSjyccqb3QolHSbeuwi5UpUph8UxdDYNmWSCH0zR/zE2hFypgk21xA==}
 
-  '@platforma-open/milaboratories.software-ptabler@2.1.5':
-    resolution: {integrity: sha512-bZgDa+KJyAgKKu/Ka+Hzh7thZU/PkmupMRUvXV1ruLdJoxvIcyOj9ehQuVi5DapX4sE7iQ5EkavqpK59z0oZ8w==}
+  '@platforma-open/milaboratories.software-ptabler@2.1.6':
+    resolution: {integrity: sha512-LdDU9/z+iejw5F98J8DYVQKsjUGGiyu8rHWCjWCEqOVEP+N9QBcN4ibDgG4Xp/GL+IzKxicAkf2Ae9lHollD6w==}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.3':
     resolution: {integrity: sha512-5wwzvPko/tjkm6EnirsnjB+MO5mF//tgJplI+jPh3bcSHpEdHF+B9xg+S1owAnekqbimMrFZWqHSVY9ZmIHOjw==}
@@ -1616,33 +1623,33 @@ packages:
   '@platforma-open/milaboratories.software-small-binaries@2.1.1':
     resolution: {integrity: sha512-KN1PR7YgUUfx1dxh/TtcoWpSZbOXbRxXzQuJ505qHuXuE0spYwC7bXnvJsEYbEwRcPMa0foTrjBnPNORE4yr+Q==}
 
-  '@platforma-sdk/block-tools@2.12.4':
-    resolution: {integrity: sha512-qIXBByWh/UjSm26GzU0pHldS3/tkT84ijsWKROT7Zq3zFbdJ/7AFCxduqReC51/+z/kLsrvjyhJUNvLozBye0A==}
+  '@platforma-sdk/block-tools@2.12.7':
+    resolution: {integrity: sha512-a13K0hcXYf+sgx+07QFjIu2uTeTH5lhHHI1o563kvs9Z5vssU9jn7HFgXgSe6TMjDntERJcGHiGm8nUd4t3FiA==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
     resolution: {integrity: sha512-p9lBxhFXM9WoRsrJO7dfkiXSK+1m63yIn1sKhBO71eMbhrLMyVYHEOeNf3w5OCdbRF5QsNhXzWuiTmFK3zHFsA==}
     hasBin: true
 
-  '@platforma-sdk/model@1.79.27':
-    resolution: {integrity: sha512-Z5WYpClTZoBtvfGsiDPNlRCxPKtUF04TV3MmL1Kfb6xAb04B5NdiqWMnqw+v78Kue/y9FKTmxrCcX9lwZgYFlw==}
+  '@platforma-sdk/model@1.80.2':
+    resolution: {integrity: sha512-aQGVxjxw7y34U0ZuboIYASodJMZ1yTjXH2y44bCdeTeS/r81YBBmGrF6BQhHHVjIOIhaIlWHRBIhd9AJo42aWQ==}
 
   '@platforma-sdk/package-builder-lib@1.2.0':
     resolution: {integrity: sha512-AtSzaZ39BGlqcyYtpGREDz+YlGCDdSTQJNV/+NkTyUtoq1ECRO+iMqAX1DSSza1WqylnURX8vKVI2owS/cxntA==}
 
-  '@platforma-sdk/tengo-builder@4.0.16':
-    resolution: {integrity: sha512-08z5kIB5ZnSmvMPu3rcyGxh+yKyQ6fn6tYzq37kK+iLpXrB23fjgOAjqIF6NEq/Dkxr2dWSUa4BXa8XPBc0+SQ==}
+  '@platforma-sdk/tengo-builder@4.0.18':
+    resolution: {integrity: sha512-nGPB5fE6b9ITFuXVMRakr2MyqsnL4TVE09jZ2X7TCPgb31k4gIhYCT+XU9vBRavBj/U3dt+jSWHkcbX9JvJKYA==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/test@1.79.34':
-    resolution: {integrity: sha512-Vo+krqfnpnI2IE3Nkbc8HOYGSqf/tp/mbuPCj/6V02WB6/LzyXWsjfp4ZbTkt+75UqSm3blNfeyi8piNg6QWJA==}
+  '@platforma-sdk/test@1.80.5':
+    resolution: {integrity: sha512-z3tBrNWIg0+OfUOKpiZWCFflSW17J/Tv7DRWK99IzaaS0+MrIhC6oEFJGXnDlbynhnhSp3E+a4HiwEe+SG/rCg==}
 
-  '@platforma-sdk/ui-vue@1.79.34':
-    resolution: {integrity: sha512-n2u4sjtVFh5amrIXiLQ0LA8OlJdtQ+ZMAr8aqSacxfHkBSUR1my5TVOSxfZ6xA8Huief2T4ERsEeJAqyLS7v+w==}
+  '@platforma-sdk/ui-vue@1.80.4':
+    resolution: {integrity: sha512-DQbuO3fAJ3CQxiJkXMiNuo1Qyd/C92AatOZX90ElLFohXiP3XbJNXNjrIxypzsUc850dKkqbPjKd0JTzD12E9w==}
 
-  '@platforma-sdk/workflow-tengo@6.7.1':
-    resolution: {integrity: sha512-8vAXzDzDZpHncMHSuTjesuD/tOWWRhWyQIr8jH2MBgWJGkUXUtoDLBqYk6l5knHrYfrorDzXjsnsFQCzU0bI1A==}
+  '@platforma-sdk/workflow-tengo@6.7.2':
+    resolution: {integrity: sha512-KJ4tBigEDN+EIDy7K2u7PqxBIDrhwvnazJthApGg2N/HPZkinKmq0iMzHC9KZ0IsJVg6uxECIB2d2Acko33tOw==}
 
   '@protobuf-ts/grpc-transport@2.11.1':
     resolution: {integrity: sha512-l6wrcFffY+tuNnuyrNCkRM8hDIsAZVLA8Mn7PKdVyYxITosYh60qW663p9kL6TWXYuDCL3oxH8ih3vLKTDyhtg==}
@@ -7969,21 +7976,26 @@ snapshots:
 
   '@microsoft/tsdoc@0.16.0': {}
 
-  '@milaboratories/computable@2.9.6':
+  '@milaboratories/columns-collection-driver@0.2.1':
+    dependencies:
+      '@milaboratories/helpers': 1.14.4
+      '@milaboratories/pl-model-common': 1.47.1
+
+  '@milaboratories/computable@2.9.7':
     dependencies:
       '@milaboratories/pl-error-like': 1.12.10
-      '@milaboratories/ts-helpers': 1.8.4
+      '@milaboratories/ts-helpers': 1.8.5
       '@types/node': 24.5.2
       utility-types: 3.11.0
 
-  '@milaboratories/graph-maker@1.6.1(@milaboratories/pl-model-common@1.46.4)(@platforma-sdk/model@1.79.27)(@platforma-sdk/ui-vue@1.79.34(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)':
+  '@milaboratories/graph-maker@1.6.1(@milaboratories/pl-model-common@1.47.1)(@platforma-sdk/model@1.80.2)(@platforma-sdk/ui-vue@1.80.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)':
     dependencies:
       '@ag-grid-community/core': 32.3.9
       '@milaboratories/helpers': 1.14.3
       '@milaboratories/miplots4': 1.4.0(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.5.0(@milaboratories/pl-model-common@1.46.4)(@platforma-sdk/model@1.79.27)
-      '@platforma-sdk/model': 1.79.27
-      '@platforma-sdk/ui-vue': 1.79.34(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
+      '@milaboratories/pf-plots': 1.5.0(@milaboratories/pl-model-common@1.47.1)(@platforma-sdk/model@1.80.2)
+      '@platforma-sdk/model': 1.80.2
+      '@platforma-sdk/ui-vue': 1.80.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
       '@types/d3-hierarchy': 3.1.7
       '@types/d3-scale': 4.0.9
       '@vueuse/core': 13.9.0(vue@3.5.26(typescript@5.9.3))
@@ -8003,6 +8015,8 @@ snapshots:
   '@milaboratories/helpers@1.14.2': {}
 
   '@milaboratories/helpers@1.14.3': {}
+
+  '@milaboratories/helpers@1.14.4': {}
 
   '@milaboratories/miplots4@1.4.0(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)':
     dependencies:
@@ -8042,14 +8056,14 @@ snapshots:
       - d3-scale-chromatic
       - supports-color
 
-  '@milaboratories/pf-driver@1.7.16(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pf-driver@1.8.2(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
-      '@milaboratories/helpers': 1.14.3
-      '@milaboratories/pframes-rs-node': 1.1.52
-      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.4)(@milaboratories/pl-model-middle-layer@1.30.11)
-      '@milaboratories/pl-model-common': 1.46.4
-      '@milaboratories/pl-model-middle-layer': 1.30.11
-      '@milaboratories/ts-helpers': 1.8.4
+      '@milaboratories/helpers': 1.14.4
+      '@milaboratories/pframes-rs-node': 1.1.55
+      '@milaboratories/pframes-rs-wasm': 1.1.55(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.47.1)(@milaboratories/pl-model-middle-layer@1.30.13)
+      '@milaboratories/pl-model-common': 1.47.1
+      '@milaboratories/pl-model-middle-layer': 1.30.13
+      '@milaboratories/ts-helpers': 1.8.5
       es-toolkit: 1.39.10
       lru-cache: 11.2.4
     transitivePeerDependencies:
@@ -8057,36 +8071,36 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pf-plots@1.5.0(@milaboratories/pl-model-common@1.46.4)(@platforma-sdk/model@1.79.27)':
+  '@milaboratories/pf-plots@1.5.0(@milaboratories/pl-model-common@1.47.1)(@platforma-sdk/model@1.80.2)':
     dependencies:
       '@milaboratories/helpers': 1.14.3
-      '@milaboratories/pl-model-common': 1.46.4
-      '@platforma-sdk/model': 1.79.27
+      '@milaboratories/pl-model-common': 1.47.1
+      '@platforma-sdk/model': 1.80.2
       canonicalize: 2.1.0
       lodash: 4.17.21
 
-  '@milaboratories/pf-spec-driver@1.4.18(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pf-spec-driver@1.4.21(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
-      '@milaboratories/helpers': 1.14.3
-      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.4)(@milaboratories/pl-model-middle-layer@1.30.11)
-      '@milaboratories/pl-model-common': 1.46.4
-      '@milaboratories/pl-model-middle-layer': 1.30.11
+      '@milaboratories/helpers': 1.14.4
+      '@milaboratories/pframes-rs-wasm': 1.1.55(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.47.1)(@milaboratories/pl-model-middle-layer@1.30.13)
+      '@milaboratories/pl-model-common': 1.47.1
+      '@milaboratories/pl-model-middle-layer': 1.30.13
       '@noble/hashes': 2.0.1
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
 
-  '@milaboratories/pframes-rs-node@1.1.52':
+  '@milaboratories/pframes-rs-node@1.1.55':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-serv': 1.1.52
+      '@milaboratories/pframes-rs-serv': 1.1.55
       '@milaboratories/pl-model-common': 1.46.2
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.52':
+  '@milaboratories/pframes-rs-serv@1.1.55':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-model-common': 1.46.2
@@ -8095,21 +8109,21 @@ snapshots:
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasip2@1.1.52': {}
+  '@milaboratories/pframes-rs-wasip2@1.1.55': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.4)(@milaboratories/pl-model-middle-layer@1.30.11)':
+  '@milaboratories/pframes-rs-wasm@1.1.55(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.47.1)(@milaboratories/pl-model-middle-layer@1.30.13)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pframes-rs-wasip2': 1.1.52
-      '@milaboratories/pl-model-common': 1.46.4
-      '@milaboratories/pl-model-middle-layer': 1.30.11
+      '@milaboratories/pframes-rs-wasip2': 1.1.55
+      '@milaboratories/pl-model-common': 1.47.1
+      '@milaboratories/pl-model-middle-layer': 1.30.13
 
-  '@milaboratories/pl-client@3.14.0':
+  '@milaboratories/pl-client@3.14.2':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.46.4
-      '@milaboratories/ts-helpers': 1.8.4
+      '@milaboratories/pl-model-common': 1.47.1
+      '@milaboratories/ts-helpers': 1.8.5
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
@@ -8122,19 +8136,19 @@ snapshots:
       utility-types: 3.11.0
       yaml: 2.8.2
 
-  '@milaboratories/pl-config@1.8.3':
+  '@milaboratories/pl-config@1.8.4':
     dependencies:
-      '@milaboratories/ts-helpers': 1.8.4
+      '@milaboratories/ts-helpers': 1.8.5
       upath: 2.0.1
       yaml: 2.8.2
 
-  '@milaboratories/pl-deployments@3.0.10':
+  '@milaboratories/pl-deployments@3.0.12':
     dependencies:
-      '@milaboratories/pl-config': 1.8.3
-      '@milaboratories/pl-healthcheck': 1.0.2
+      '@milaboratories/pl-config': 1.8.4
+      '@milaboratories/pl-healthcheck': 1.0.3
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.46.4
-      '@milaboratories/ts-helpers': 1.8.4
+      '@milaboratories/pl-model-common': 1.47.1
+      '@milaboratories/ts-helpers': 1.8.5
       decompress: 4.2.1
       ssh2: 1.17.0
       tar: 7.5.2
@@ -8143,15 +8157,15 @@ snapshots:
       yaml: 2.8.2
       zod: 3.25.76
 
-  '@milaboratories/pl-drivers@1.16.8':
+  '@milaboratories/pl-drivers@1.16.10':
     dependencies:
       '@grpc/grpc-js': 1.13.4
-      '@milaboratories/computable': 2.9.6
-      '@milaboratories/helpers': 1.14.3
-      '@milaboratories/pl-client': 3.14.0
-      '@milaboratories/pl-model-common': 1.46.4
-      '@milaboratories/pl-tree': 1.12.19
-      '@milaboratories/ts-helpers': 1.8.4
+      '@milaboratories/computable': 2.9.7
+      '@milaboratories/helpers': 1.14.4
+      '@milaboratories/pl-client': 3.14.2
+      '@milaboratories/pl-model-common': 1.47.1
+      '@milaboratories/pl-tree': 1.13.1
+      '@milaboratories/ts-helpers': 1.8.5
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/plugin': 2.11.1
       '@protobuf-ts/runtime': 2.11.1
@@ -8173,16 +8187,16 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.25.76
 
-  '@milaboratories/pl-errors@1.4.29':
+  '@milaboratories/pl-errors@1.4.31':
     dependencies:
-      '@milaboratories/pl-client': 3.14.0
-      '@milaboratories/ts-helpers': 1.8.4
+      '@milaboratories/pl-client': 3.14.2
+      '@milaboratories/ts-helpers': 1.8.5
       zod: 3.25.76
 
-  '@milaboratories/pl-healthcheck@1.0.2':
+  '@milaboratories/pl-healthcheck@1.0.3':
     dependencies:
       '@grpc/grpc-js': 1.13.4
-      '@milaboratories/ts-helpers': 1.8.4
+      '@milaboratories/ts-helpers': 1.8.5
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
@@ -8191,28 +8205,29 @@ snapshots:
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-middle-layer@1.65.9(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)':
+  '@milaboratories/pl-middle-layer@1.66.4(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)':
     dependencies:
-      '@milaboratories/computable': 2.9.6
-      '@milaboratories/helpers': 1.14.3
-      '@milaboratories/pf-driver': 1.7.16(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pf-spec-driver': 1.4.18(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pframes-rs-node': 1.1.52
-      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.4)(@milaboratories/pl-model-middle-layer@1.30.11)
-      '@milaboratories/pl-client': 3.14.0
-      '@milaboratories/pl-deployments': 3.0.10
-      '@milaboratories/pl-drivers': 1.16.8
-      '@milaboratories/pl-errors': 1.4.29
+      '@milaboratories/columns-collection-driver': 0.2.1
+      '@milaboratories/computable': 2.9.7
+      '@milaboratories/helpers': 1.14.4
+      '@milaboratories/pf-driver': 1.8.2(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pf-spec-driver': 1.4.21(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pframes-rs-node': 1.1.55
+      '@milaboratories/pframes-rs-wasm': 1.1.55(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.47.1)(@milaboratories/pl-model-middle-layer@1.30.13)
+      '@milaboratories/pl-client': 3.14.2
+      '@milaboratories/pl-deployments': 3.0.12
+      '@milaboratories/pl-drivers': 1.16.10
+      '@milaboratories/pl-errors': 1.4.31
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.4.14
-      '@milaboratories/pl-model-common': 1.46.4
-      '@milaboratories/pl-model-middle-layer': 1.30.11
-      '@milaboratories/pl-tree': 1.12.19
+      '@milaboratories/pl-model-backend': 1.4.16
+      '@milaboratories/pl-model-common': 1.47.1
+      '@milaboratories/pl-model-middle-layer': 1.30.13
+      '@milaboratories/pl-tree': 1.13.1
       '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.8.4
-      '@platforma-sdk/block-tools': 2.12.4(@types/node@24.5.2)
-      '@platforma-sdk/model': 1.79.27
-      '@platforma-sdk/workflow-tengo': 6.7.1
+      '@milaboratories/ts-helpers': 1.8.5
+      '@platforma-sdk/block-tools': 2.12.7(@types/node@24.5.2)
+      '@platforma-sdk/model': 1.80.2
+      '@platforma-sdk/workflow-tengo': 6.7.2
       canonicalize: 2.1.0
       denque: 2.1.0
       es-toolkit: 1.39.10
@@ -8232,9 +8247,9 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@milaboratories/pl-model-backend@1.4.14':
+  '@milaboratories/pl-model-backend@1.4.16':
     dependencies:
-      '@milaboratories/pl-client': 3.14.0
+      '@milaboratories/pl-client': 3.14.2
       canonicalize: 2.1.0
       zod: 3.25.76
 
@@ -8245,17 +8260,18 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-common@1.46.4':
+  '@milaboratories/pl-model-common@1.47.1':
     dependencies:
-      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/helpers': 1.14.4
       '@milaboratories/pl-error-like': 1.12.10
       canonicalize: 2.1.0
+      es-toolkit: 1.39.10
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.30.11':
+  '@milaboratories/pl-model-middle-layer@1.30.13':
     dependencies:
-      '@milaboratories/helpers': 1.14.3
-      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/helpers': 1.14.4
+      '@milaboratories/pl-model-common': 1.47.1
       es-toolkit: 1.39.10
       utility-types: 3.11.0
       zod: 3.25.76
@@ -8268,19 +8284,19 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/pl-tree@1.12.19':
+  '@milaboratories/pl-tree@1.13.1':
     dependencies:
-      '@milaboratories/computable': 2.9.6
-      '@milaboratories/pl-client': 3.14.0
-      '@milaboratories/pl-errors': 1.4.29
-      '@milaboratories/ts-helpers': 1.8.4
+      '@milaboratories/computable': 2.9.7
+      '@milaboratories/pl-client': 3.14.2
+      '@milaboratories/pl-errors': 1.4.31
+      '@milaboratories/ts-helpers': 1.8.5
       denque: 2.1.0
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/ptabler-expression-js@1.2.33':
+  '@milaboratories/ptabler-expression-js@1.2.35':
     dependencies:
-      '@platforma-open/milaboratories.software-ptabler.schema': 1.15.17
+      '@platforma-open/milaboratories.software-ptabler.schema': 1.15.19
 
   '@milaboratories/resolve-helper@1.1.3': {}
 
@@ -8413,16 +8429,16 @@ snapshots:
 
   '@milaboratories/ts-configs@1.3.0': {}
 
-  '@milaboratories/ts-helpers@1.8.4':
+  '@milaboratories/ts-helpers@1.8.5':
     dependencies:
-      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/helpers': 1.14.4
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/uikit@2.15.14(typescript@5.9.3)':
+  '@milaboratories/uikit@2.15.16(typescript@5.9.3)':
     dependencies:
-      '@milaboratories/helpers': 1.14.3
-      '@platforma-sdk/model': 1.79.27
+      '@milaboratories/helpers': 1.14.4
+      '@platforma-sdk/model': 1.80.2
       '@types/d3-array': 3.2.2
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -8711,11 +8727,11 @@ snapshots:
       '@platforma-open/milaboratories.runenv-python-3.12.10-atls': 1.1.12
       '@platforma-open/milaboratories.runenv-python-3.12.10-sccoda': 1.2.12
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.15.17':
+  '@platforma-open/milaboratories.software-ptabler.schema@1.15.19':
     dependencies:
-      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/pl-model-common': 1.47.1
 
-  '@platforma-open/milaboratories.software-ptabler@2.1.5': {}
+  '@platforma-open/milaboratories.software-ptabler@2.1.6': {}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.3': {}
 
@@ -8739,17 +8755,17 @@ snapshots:
       '@platforma-open/milaboratories.software-small-binaries.mnz-client': 1.6.5
       '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.5
 
-  '@platforma-sdk/block-tools@2.12.4(@types/node@24.5.2)':
+  '@platforma-sdk/block-tools@2.12.7(@types/node@24.5.2)':
     dependencies:
       '@aws-sdk/client-ecr-public': 3.859.0
       '@aws-sdk/client-s3': 3.859.0
       '@inquirer/prompts': 7.10.1(@types/node@24.5.2)
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.4.14
-      '@milaboratories/pl-model-common': 1.46.4
-      '@milaboratories/pl-model-middle-layer': 1.30.11
+      '@milaboratories/pl-model-backend': 1.4.16
+      '@milaboratories/pl-model-common': 1.47.1
+      '@milaboratories/pl-model-middle-layer': 1.30.13
       '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.8.4
+      '@milaboratories/ts-helpers': 1.8.5
       '@platforma-sdk/blocks-deps-updater': 2.2.0
       '@platforma-sdk/package-builder-lib': 1.2.0
       canonicalize: 2.1.0
@@ -8769,16 +8785,17 @@ snapshots:
     dependencies:
       yaml: 2.8.2
 
-  '@platforma-sdk/model@1.79.27':
+  '@platforma-sdk/model@1.80.2':
     dependencies:
-      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/helpers': 1.14.4
       '@milaboratories/pl-error-like': 1.12.10
-      '@milaboratories/pl-model-common': 1.46.4
-      '@milaboratories/pl-model-middle-layer': 1.30.11
-      '@milaboratories/ptabler-expression-js': 1.2.33
+      '@milaboratories/pl-model-common': 1.47.1
+      '@milaboratories/pl-model-middle-layer': 1.30.13
+      '@milaboratories/ptabler-expression-js': 1.2.35
       canonicalize: 2.1.0
       es-toolkit: 1.39.10
       fast-json-patch: 3.1.1
+      lru-cache: 11.2.4
       utility-types: 3.11.0
       zod: 3.25.76
 
@@ -8796,22 +8813,22 @@ snapshots:
       - aws-crt
       - react-native-b4a
 
-  '@platforma-sdk/tengo-builder@4.0.16':
+  '@platforma-sdk/tengo-builder@4.0.18':
     dependencies:
-      '@milaboratories/pl-model-backend': 1.4.14
+      '@milaboratories/pl-model-backend': 1.4.16
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/tengo-tester': 1.6.4
-      '@milaboratories/ts-helpers': 1.8.4
+      '@milaboratories/ts-helpers': 1.8.5
       commander: 15.0.0
       winston: 3.17.0
 
-  '@platforma-sdk/test@1.79.34(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@6.4.1(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.0)(yaml@2.8.2))':
+  '@platforma-sdk/test@1.80.5(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@6.4.1(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.0)(yaml@2.8.2))':
     dependencies:
-      '@milaboratories/computable': 2.9.6
-      '@milaboratories/pl-client': 3.14.0
-      '@milaboratories/pl-middle-layer': 1.65.9(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
-      '@milaboratories/pl-tree': 1.12.19
-      '@platforma-sdk/model': 1.79.27
+      '@milaboratories/computable': 2.9.7
+      '@milaboratories/pl-client': 3.14.2
+      '@milaboratories/pl-middle-layer': 1.66.4(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
+      '@milaboratories/pl-tree': 1.13.1
+      '@platforma-sdk/model': 1.80.2
       '@vitest/coverage-istanbul': 4.1.4(vitest@4.0.16(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.0)(yaml@2.8.2))
       vitest: 4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4)(vite@6.4.1(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.0)(yaml@2.8.2))
     transitivePeerDependencies:
@@ -8834,13 +8851,13 @@ snapshots:
       - supports-color
       - vite
 
-  '@platforma-sdk/test@1.79.34(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.0)(yaml@2.8.2))':
+  '@platforma-sdk/test@1.80.5(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.0)(yaml@2.8.2))':
     dependencies:
-      '@milaboratories/computable': 2.9.6
-      '@milaboratories/pl-client': 3.14.0
-      '@milaboratories/pl-middle-layer': 1.65.9(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
-      '@milaboratories/pl-tree': 1.12.19
-      '@platforma-sdk/model': 1.79.27
+      '@milaboratories/computable': 2.9.7
+      '@milaboratories/pl-client': 3.14.2
+      '@milaboratories/pl-middle-layer': 1.66.4(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
+      '@milaboratories/pl-tree': 1.13.1
+      '@platforma-sdk/model': 1.80.2
       '@vitest/coverage-istanbul': 4.1.4(vitest@4.1.4)
       vitest: 4.1.4(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.4)(vite@8.0.8(@types/node@24.5.2)(sass-embedded@1.89.0)(yaml@2.8.2))
     transitivePeerDependencies:
@@ -8863,12 +8880,13 @@ snapshots:
       - supports-color
       - vite
 
-  '@platforma-sdk/ui-vue@1.79.34(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
+  '@platforma-sdk/ui-vue@1.80.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
     dependencies:
-      '@milaboratories/pf-spec-driver': 1.4.18(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pl-model-common': 1.46.4
-      '@milaboratories/uikit': 2.15.14(typescript@5.9.3)
-      '@platforma-sdk/model': 1.79.27
+      '@milaboratories/columns-collection-driver': 0.2.1
+      '@milaboratories/pf-spec-driver': 1.4.21(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pl-model-common': 1.47.1
+      '@milaboratories/uikit': 2.15.16(typescript@5.9.3)
+      '@platforma-sdk/model': 1.80.2
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.1
@@ -8899,11 +8917,11 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@platforma-sdk/workflow-tengo@6.7.1':
+  '@platforma-sdk/workflow-tengo@6.7.2':
     dependencies:
-      '@milaboratories/pframes-rs-wasip2': 1.1.52
+      '@milaboratories/pframes-rs-wasip2': 1.1.55
       '@milaboratories/software-pframes-conv': 2.2.9
-      '@platforma-open/milaboratories.software-ptabler': 2.1.5
+      '@platforma-open/milaboratories.software-ptabler': 2.1.6
       '@platforma-open/milaboratories.software-ptexter': 1.2.3
       '@platforma-open/milaboratories.software-small-binaries': 2.1.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,13 +10,13 @@ catalog:
   # SDK packages - EXACT VERSIONS (no ^ or ~)
   '@milaboratories/ts-builder': 1.6.0
   '@milaboratories/ts-configs': 1.3.0
-  '@platforma-sdk/workflow-tengo': 6.7.1
-  '@platforma-sdk/model': 1.79.27
-  '@platforma-sdk/ui-vue': 1.79.34
-  '@platforma-sdk/tengo-builder': 4.0.16
-  '@platforma-sdk/block-tools': 2.12.4
-  '@platforma-sdk/test': 1.79.34
-  '@milaboratories/helpers': 1.14.3
+  '@platforma-sdk/workflow-tengo': 6.7.2
+  '@platforma-sdk/model': 1.80.2
+  '@platforma-sdk/ui-vue': 1.80.4
+  '@platforma-sdk/tengo-builder': 4.0.18
+  '@platforma-sdk/block-tools': 2.12.7
+  '@platforma-sdk/test': 1.80.5
+  '@milaboratories/helpers': 1.14.4
 
   # Block-specific dependencies
   "@milaboratories/graph-maker": 1.6.1
@@ -34,3 +34,4 @@ catalog:
   'eslint': ^9.25.1
   'sass-embedded': ^1.77.8
   '@changesets/cli': ^2.29.8
+  "@platforma-sdk/package-builder": 3.14.1


### PR DESCRIPTION
Refresh SDK dependencies and block structure via `pnpm upgrade-sdk`.

This runs:
- `block-tools structure refresh --update-deps-only` + `pnpm i`
- `block-tools structure refresh` + `pnpm i`
- `pnpm fmt`

Includes a patch changeset ("SDK Update").

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR performs a routine SDK dependency refresh via `pnpm upgrade-sdk`, bumping all `@platforma-sdk/*` and several `@milaboratories/*` packages to their latest versions, and ships a patch changeset to version the four workspace packages.

- **`pnpm-workspace.yaml`**: Catalog entries updated to exact new versions for all SDK packages (`@platforma-sdk/model` 1.79.27→1.80.2, `@platforma-sdk/ui-vue` 1.79.34→1.80.4, `@platforma-sdk/test` 1.79.34→1.80.5, `@platforma-sdk/workflow-tengo` 6.7.1→6.7.2, `@platforma-sdk/block-tools` 2.12.4→2.12.7, `@platforma-sdk/tengo-builder` 4.0.16→4.0.18, `@milaboratories/helpers` 1.14.3→1.14.4).
- **`pnpm-lock.yaml`**: Lockfile regenerated with consistent resolutions across all importers; a new transitive package `@milaboratories/columns-collection-driver@0.2.1` is introduced, and several inner `@milaboratories/pl-*` packages are bumped in lock-step.
- **`.changeset/upgrade-sdk.md`**: Patch changeset created for all four workspace packages (`clonotype-enrichment`, `.model`, `.ui`, `.workflow`).

**Touched terms and their changes:**

| Term | Definition | Change |
|------|-----------|--------|
| `@platforma-sdk/model` | Core type definitions and APIs for block input/output models | 1.79.27 → 1.80.2 (minor) |
| `@platforma-sdk/ui-vue` | Vue 3 UI component library used by block UIs | 1.79.34 → 1.80.4 (minor) |
| `@platforma-sdk/test` | Testing utilities and harness for block integration tests | 1.79.34 → 1.80.5 (minor) |
| `@platforma-sdk/workflow-tengo` | Tengo-language runtime and standard library for block workflows | 6.7.1 → 6.7.2 (patch) |
| `@platforma-sdk/block-tools` | CLI toolchain for scaffolding and refreshing block structure | 2.12.4 → 2.12.7 (patch) |
| `@milaboratories/pl-model-common` | Shared low-level platform model primitives (ref types, axes, etc.) | 1.46.4 → 1.47.1 (minor) |
| `@milaboratories/pl-middle-layer` | Platform middle-layer server, sits between the client and drivers | 1.65.9 → 1.66.4 (minor) |
| `@milaboratories/columns-collection-driver` | New transitive driver package for column-collection data access | Added at 0.2.1 |

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Routine automated SDK version bump with no logic or API surface changes; all catalog and lockfile entries are internally consistent.

All three changed files are generated by the pnpm upgrade-sdk toolchain. The catalog versions in pnpm-workspace.yaml match the resolved versions in pnpm-lock.yaml exactly. The only substantive addition is the new transitive package @milaboratories/columns-collection-driver@0.2.1, which carries no direct usage in this block's source. The changeset correctly marks all four workspace packages for a patch release.

No files require special attention; all changes are generated lockfile and catalog updates.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .changeset/upgrade-sdk.md | New patch changeset bumping all four workspace packages for the SDK update. |
| pnpm-workspace.yaml | Catalog versions updated to match new SDK releases; all entries are consistent with the lockfile. |
| pnpm-lock.yaml | Lockfile regenerated to reflect catalog bumps; introduces new transitive dependency @milaboratories/columns-collection-driver@0.2.1; all peer-dep resolutions are consistent. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pnpm upgrade-sdk] --> B[block-tools structure refresh]
    B --> C[pnpm i]
    C --> D[pnpm fmt]
    D --> G{Files Changed}
    G --> H[pnpm-workspace.yaml\nCatalog version bumps]
    G --> I[pnpm-lock.yaml\nLockfile regenerated]
    G --> J[changeset/upgrade-sdk.md\nPatch changeset added]
    H --> K[model 1.79.27 to 1.80.2]
    H --> L[ui-vue 1.79.34 to 1.80.4]
    H --> M[test 1.79.34 to 1.80.5]
    H --> N[workflow-tengo 6.7.1 to 6.7.2]
    H --> O[block-tools 2.12.4 to 2.12.7]
    I --> P[New transitive dep\ncolumns-collection-driver v0.2.1]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[pnpm upgrade-sdk] --> B[block-tools structure refresh]
    B --> C[pnpm i]
    C --> D[pnpm fmt]
    D --> G{Files Changed}
    G --> H[pnpm-workspace.yaml\nCatalog version bumps]
    G --> I[pnpm-lock.yaml\nLockfile regenerated]
    G --> J[changeset/upgrade-sdk.md\nPatch changeset added]
    H --> K[model 1.79.27 to 1.80.2]
    H --> L[ui-vue 1.79.34 to 1.80.4]
    H --> M[test 1.79.34 to 1.80.5]
    H --> N[workflow-tengo 6.7.1 to 6.7.2]
    H --> O[block-tools 2.12.4 to 2.12.7]
    I --> P[New transitive dep\ncolumns-collection-driver v0.2.1]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: refresh SDK dependencies and bloc..."](https://github.com/platforma-open/clonotype-enrichment/commit/7b129c473926f684b7e1a4e5f2bba71719d73e2d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44501401)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->