### PR TITLE
Milab-6626: maxfreq trace dataset

### DIFF
--- a/.changeset/milab-6626-maxfreq-trace.md
+++ b/.changeset/milab-6626-maxfreq-trace.md
@@ -1,0 +1,6 @@
+---
+"@platforma-open/milaboratories.clonotype-enrichment": patch
+"@platforma-open/milaboratories.clonotype-enrichment.workflow": patch
+---
+
+MILAB-6626: add the `condition-order` trace step (block label) to the per-element "Max Frequency" column, mirroring the enrichment columns. Previously the column carried only a single generic trace step, so when several enrichment analyses ran over the same clonotype library their "<Element> Max Frequency" columns were labelled identically and `deriveDistinctLabels` could not tell them apart downstream (e.g. duplicate "Clonotype Max Frequency" entries in the antibody-tcr-lead-selection ranking/filter lists). With the block-label step present, each column now disambiguates per block, exactly as the Log2FC columns already do. The block is named explicitly so it gets a version bump and releases — the automatic cascade from sub-packages is no longer reliable.

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -322,9 +322,16 @@ wf.body(func(args) {
 		{ cpu: 1, mem: "32GiB" })
 
 	// Prepare pFrame to be exported
+	// Two traces: condition order (block label) and downsampling
+	conditionOrderLabel := args.customBlockLabel || args.defaultBlockLabel
 	trace := pSpec.makeTrace(abundanceSpec,
 		{
-			type: "milaboratories.clonotype-enrichment",
+			type: "milaboratories.clonotype-enrichment.condition-order",
+			importance: 35,
+			label: conditionOrderLabel
+		},
+		{
+			type: "milaboratories.clonotype-enrichment.downsampling",
 			importance: 30,
 			label: label
 	})
@@ -465,9 +472,15 @@ wf.body(func(args) {
 		clonoFreqPf := xsv.importFile(clonoMaxFreq.getFile("clonotype_max_frequency.csv"), "csv", clonoFreqImportParams,
 			{ cpu: 1, mem: "16GiB" })
 
+		// Two traces: condition order (block label) and downsampling
 		clonoTrace := pSpec.makeTrace(clonoAbundanceSpec,
 			{
-				type: "milaboratories.clonotype-enrichment",
+				type: "milaboratories.clonotype-enrichment.condition-order",
+				importance: 35,
+				label: conditionOrderLabel
+			},
+			{
+				type: "milaboratories.clonotype-enrichment.downsampling",
 				importance: 30,
 				label: label
 		})


### PR DESCRIPTION
Add the condition-order (block label) trace step to the per-element Max Frequency column and the per-condition Frequency exports, mirroring the enrichment columns (enrichment-column.tpl.tengo). Previously these carried only a single generic step, so multiple enrichment analyses over the same clonotype library produced identically labelled columns that deriveDistinctLabels could not tell apart downstream (duplicate entries in the lead-selection ranking/filter lists).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This patch adds a `condition-order` trace step (carrying the block label) to both the per-condition Frequency pFrame and the per-element Max Frequency pFrame exports in `main.tpl.tengo`, mirroring the pattern already present in `enrichment-column.tpl.tengo`. Without the block-label step, multiple enrichment analyses over the same clonotype library produced identically labelled columns that `deriveDistinctLabels` could not distinguish downstream.

- **`trace` (Frequency pFrame)**: The single generic `milaboratories.clonotype-enrichment` step (importance 30) is replaced by two steps — `condition-order` (importance 35, label = block label) and `downsampling` (importance 30, label = downsampling label).
- **`clonoTrace` (per-element Max Frequency pFrame)**: Receives the identical two-step update; `conditionOrderLabel` computed at outer scope is correctly reused inside the `if inputType == "Cluster"` block.
- **Changeset**: Both the top-level package and the workflow sub-package are explicitly bumped as `patch`, which the PR notes is necessary because the automatic cascade from sub-packages is no longer reliable.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted, additive fix that aligns two previously under-labelled trace calls with an established pattern already in production.

Both the per-condition Frequency trace and the per-element Max Frequency trace now carry a block-label step, exactly mirroring enrichment-column.tpl.tengo. The conditionOrderLabel variable is defined in outer scope and is correctly accessible inside the inner if block. No existing logic is removed or reordered; the old generic trace type is cleanly replaced by two specific subtypes with matching importance levels.

No files require special attention. The changeset correctly names both packages for an explicit version bump.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| workflow/src/main.tpl.tengo | Adds conditionOrderLabel and splits the single generic trace step into condition-order + downsampling for both the per-condition Frequency pFrame and per-element Max Frequency pFrame, mirroring enrichment-column.tpl.tengo. |
| .changeset/milab-6626-maxfreq-trace.md | New changeset entry correctly bumping both the root package and workflow sub-package as patch releases. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["wf.body(args)"] --> B["conditionOrderLabel\n:= args.customBlockLabel || args.defaultBlockLabel"]
    B --> C["trace = pSpec.makeTrace(abundanceSpec, ...)"]
    C --> C1["step 1: condition-order\nimportance: 35, label: conditionOrderLabel"]
    C --> C2["step 2: downsampling\nimportance: 30, label: label"]
    C1 & C2 --> D["Frequency pFrame (per-condition exports)"]
    B --> E{"inputType == Cluster && clonotypeAbundanceRef?"}
    E -- yes --> F["clonoTrace = pSpec.makeTrace(clonoAbundanceSpec, ...)"]
    F --> F1["step 1: condition-order\nimportance: 35, label: conditionOrderLabel"]
    F --> F2["step 2: downsampling\nimportance: 30, label: label"]
    F1 & F2 --> G["Max Frequency pFrame (per-element export)"]
    E -- no --> H["clonotypeFrequencyExport = undefined"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["wf.body(args)"] --> B["conditionOrderLabel\n:= args.customBlockLabel || args.defaultBlockLabel"]
    B --> C["trace = pSpec.makeTrace(abundanceSpec, ...)"]
    C --> C1["step 1: condition-order\nimportance: 35, label: conditionOrderLabel"]
    C --> C2["step 2: downsampling\nimportance: 30, label: label"]
    C1 & C2 --> D["Frequency pFrame (per-condition exports)"]
    B --> E{"inputType == Cluster && clonotypeAbundanceRef?"}
    E -- yes --> F["clonoTrace = pSpec.makeTrace(clonoAbundanceSpec, ...)"]
    F --> F1["step 1: condition-order\nimportance: 35, label: conditionOrderLabel"]
    F --> F2["step 2: downsampling\nimportance: 30, label: label"]
    F1 & F2 --> G["Max Frequency pFrame (per-element export)"]
    E -- no --> H["clonotypeFrequencyExport = undefined"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6626: disambiguate per-block Max F..."](https://github.com/platforma-open/clonotype-enrichment/commit/97327c88b13e7c011e56e90f2dde2f801c39b04a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45059289)</sub>

<!-- /greptile_comment -->