### PR TITLE
Release software

### DIFF
--- a/.changeset/release-software.md
+++ b/.changeset/release-software.md
@@ -1,0 +1,7 @@
+---
+"@platforma-open/milaboratories.clonotype-enrichment": patch
+"@platforma-open/milaboratories.clonotype-enrichment.software": patch
+"@platforma-open/milaboratories.clonotype-enrichment.workflow": patch
+---
+
+Release software


### PR DESCRIPTION
Adds a changeset to republish the software package(s) against the upgraded SDK. The merged `chore/upgrade-sdk` PR bumped model/ui/workflow but omitted the software package, so the software artifacts were never rebuilt. This patches the software package (and workflow, which references it) so a new software version is published on merge.